### PR TITLE
tests: an npm-incumbent corpus, frozen-installed under nub and checked against its lockfile

### DIFF
--- a/.github/workflows/npm-corpus.yml
+++ b/.github/workflows/npm-corpus.yml
@@ -1,0 +1,186 @@
+name: npm corpus
+# Real npm-incumbent projects, pinned by commit, frozen-installed under nub from their own
+# package-lock.json on a cold store and checked against that lockfile. The verdict per
+# project is the contract `npm ci` gives them: the install completes, lifecycle scripts
+# included, and every declared dependency resolves at the pinned version. Harness, corpus
+# and classification rules: tests/npm-corpus/README.md.
+#
+# nub is built ONCE and reused across every project leg; each leg runs on the Node version
+# the project's own CI uses (actions/setup-node), so a leg failing for a version-banded
+# reason fails on the version that project would actually hit. Legs are capped in parallel
+# because each one is a network-bound install of hundreds to thousands of packages.
+#
+# Cadence: push to main and PRs that touch the package-manager surface (opt-in through the
+# `ci` label, per ci.yml), a nightly run that also times `npm ci` on every project as the
+# control, and on demand with an optional project filter.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "vendor/aube/**"
+      - "crates/nub-cli/src/pm_engine/**"
+      - "crates/nub-cli/src/cli.rs"
+      - "tests/npm-corpus/**"
+      - ".github/workflows/npm-corpus.yml"
+  pull_request:
+    # PR CI is opt-in — request a run with `gh pr edit <n> --add-label ci`. Rationale: ci.yml.
+    types: [labeled]
+    branches: [main]
+    paths:
+      - "vendor/aube/**"
+      - "crates/nub-cli/src/pm_engine/**"
+      - "crates/nub-cli/src/cli.rs"
+      - "tests/npm-corpus/**"
+      - ".github/workflows/npm-corpus.yml"
+  schedule:
+    # Nightly at 09:00 UTC, offset from the lockfile-roundtrip (07:00) and pnpm-conformance
+    # (08:00) nightlies so the three sweeps do not contend for the same runner slots.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: "Projects to run (owner/repo, comma-separated); empty runs the whole corpus"
+        default: ""
+        type: string
+      control:
+        description: "When to run `npm ci` as the control"
+        default: "on-failure"
+        type: choice
+        options: [on-failure, always, never]
+
+permissions: {}
+
+# The push and schedule triggers share refs/heads/main, so a nightly cancels an in-flight
+# push run; the gate below accepts `cancelled` for exactly that reason.
+concurrency:
+  group: npm-corpus-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    name: Plan
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: "24"
+      - id: plan
+        env:
+          # `inputs` is defined only for workflow_dispatch; `github.event.inputs` is empty elsewhere.
+          REPOS: ${{ github.event.inputs.repos || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(node tests/npm-corpus/matrix.mjs "$REPOS")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "$matrix" | node -e 'const m = JSON.parse(require("fs").readFileSync(0, "utf8")); console.log(`${m.include.length} project(s):`, m.include.map((e) => `${e.repo}@node${e.node}`).join(" "))'
+
+  build:
+    name: Build nub (once)
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable # zizmor: ignore[impostor-commit,ref-version-mismatch] dtolnay force-pushes its version tags, so pinned SHAs go unreachable; commit verified genuine upstream
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6  # v2.9.2
+        with:
+          shared-key: npm-corpus
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: |
+            .
+            crates/nub-native
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: "24"
+      - name: Build nub + native addon
+        shell: bash
+        run: |
+          cargo build -p nub-cli
+          (cd crates/nub-native && cargo build)
+          mkdir -p runtime/addons
+          cp target/debug/libnub_native.so runtime/addons/nub-native.node
+      - name: Stage the reusable nub bundle
+        shell: bash
+        run: |
+          mkdir -p nub-bundle
+          cp target/debug/nub nub-bundle/nub
+          cp -r runtime nub-bundle/runtime
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nub-corpus-bundle
+          path: nub-bundle
+          retention-days: 1
+
+  corpus:
+    name: ${{ matrix.repo }} (node ${{ matrix.node }})
+    needs: [plan, build]
+    if: github.event_name != 'pull_request' || github.event.label.name == 'ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
+        with:
+          node-version: ${{ matrix.node }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: nub-corpus-bundle
+          path: nub-bundle
+      - name: Frozen-install under nub and check the tree
+        env:
+          REPO: ${{ matrix.repo }}
+          # The nightly times `npm ci` on every project; other runs only classify a red.
+          CONTROL: ${{ github.event_name == 'schedule' && 'always' || (github.event.inputs.control || 'on-failure') }}
+        shell: bash
+        run: |
+          chmod +x nub-bundle/nub tests/npm-corpus/run.sh
+          tests/npm-corpus/run.sh "$PWD/nub-bundle/nub" "$REPO"
+
+  # Always-green aggregator so one stable check name summarises the fan-out. It needs the
+  # prerequisites too: a failed plan or build skips the fan-out, and a skipped fan-out must
+  # read as that failure rather than as nothing to report.
+  npm-corpus-gate:
+    name: npm corpus gate
+    needs: [plan, build, corpus]
+    if: always() && (github.event_name != 'pull_request' || github.event.label.name == 'ci')
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - shell: bash
+        run: |
+          set -euo pipefail
+          plan='${{ needs.plan.result }}'
+          build='${{ needs.build.result }}'
+          corpus='${{ needs.corpus.result }}'
+          echo "plan=$plan build=$build corpus=$corpus"
+          # Every job here shares the gate's own trigger condition, so none is skipped on its
+          # own account: a skipped fan-out means a prerequisite failed. `cancelled` is accepted
+          # because the push and nightly triggers share a concurrency group (see the top of
+          # the file); a leg that genuinely fails aggregates to `failure`, never `cancelled`.
+          ok() { [[ "$1" == "success" || "$1" == "cancelled" ]]; }
+          ok "$plan"   || { echo "plan failed"; exit 1; }
+          ok "$build"  || { echo "build failed"; exit 1; }
+          ok "$corpus" || { echo "npm corpus failed"; exit 1; }
+          echo "npm corpus gate: OK"

--- a/tests/npm-corpus/README.md
+++ b/tests/npm-corpus/README.md
@@ -1,0 +1,28 @@
+# npm-incumbent corpus
+
+Real projects whose package manager is npm, pinned by commit, frozen-installed under nub from their own `package-lock.json` on a cold store, and then checked against that lockfile. The verdict per project is the contract `npm ci` gives them today: the install completes, lifecycle scripts included, and every dependency each importer declares resolves on disk at the version the lockfile pins. This is the drop-in claim for an npm project, measured on the projects themselves rather than on synthetic fixtures; `tests/conformance/` covers the lockfile round-trip with real npm as the judge, and this corpus covers what real lockfiles contain.
+
+## What it runs
+
+`run.sh <nub-binary> [owner/repo ...]` — with no repos, the whole of `corpus.tsv`. Per project:
+
+1. shallow-clone the pinned commit;
+2. `nub install --frozen-lockfile` with a fresh `XDG_DATA_HOME`/`XDG_CACHE_HOME`, so the store is cold and the number is the one a CI runner without a cache step sees;
+3. `check-tree.mjs`: starting from the root and every workspace member, follow every dependency edge the lockfile records, resolving each edge in the lockfile by npm's path keys and on disk by the `node_modules` walk Node performs from the dependent's real directory; the two must agree on the version at every edge. The check is layout-agnostic on purpose — npm hoists everything to the root, nub's isolated linker keeps only direct dependencies there, and both satisfy the same edges. Optional dependencies are skipped (a platform mismatch drops them legitimately). A required peer must be present and satisfy the dependent's declared range, and its exact version is reported rather than judged: npm resolves a peer by where hoisting placed the dependent, nub from the dependent's own context, and both meet the package's contract. A workspace link is judged by the member directory's manifest, as `npm ci` installs it, not by the version the lockfile recorded for it.
+
+A red is classified before it counts. `CONTROL=on-failure` (the default) runs `npm ci` on the same clone with a cold npm cache; if npm fails there too, the verdict is `XFAIL-ENV` — the runner or the pin, not nub — and it does not fail the run. `CONTROL=always` runs the control for every project and prints both wall-clock times. `expected-failures.txt` lists the known reds with a reason; a listed project that passes is `XPASS-STALE` and fails the run, so a fix is recorded by deleting the line.
+
+`matrix.mjs` turns `corpus.tsv` into the GitHub Actions matrix `npm-corpus.yml` fans out over, one job per project on the Node version that project's own CI uses.
+
+## Adding a project
+
+One tab-separated line in `corpus.tsv`: `owner/repo`, the full 40-character commit, the Node version its CI runs, and a note on what the project exercises. Pin a commit whose lockfile `npm ci` accepts, and prefer projects that add a lockfile shape the corpus does not have yet — a workspace with peer-dependency importers, a `prepare` hook that builds a native addon, a `packageManager` pin — over another single-package library. Update the pin when the project's lockfile changes shape, not on every upstream commit.
+
+## Running it locally
+
+```sh
+tests/npm-corpus/run.sh target/fast/nub mochajs/mocha avajs/ava
+CONTROL=always KEEP=1 tests/npm-corpus/run.sh target/fast/nub motdotla/dotenv
+```
+
+Each project's logs land in the work dir (`<owner>__<repo>.nub.log`, `.npm.log`, `.clone.log`), which is kept on failure. The full corpus is a network-bound sweep of a few thousand packages per project; run it in CI (`gh workflow run npm-corpus.yml`, optionally with `repos=`) rather than on a development machine.

--- a/tests/npm-corpus/check-tree.mjs
+++ b/tests/npm-corpus/check-tree.mjs
@@ -1,0 +1,261 @@
+// Checks an installed tree against the project's own package-lock.json. Starting from the
+// importers — the root and every workspace member — it follows every dependency edge the
+// lockfile records, resolving each edge twice: in the lockfile, by npm's path keys, and on
+// disk, by the node_modules walk Node performs from the dependent's REAL directory. The two
+// resolutions must agree on the version at every edge, and every node reachable that way
+// must exist. Deliberately layout-agnostic: npm hoists everything to the root and nub's
+// isolated linker keeps only direct dependencies there, and both satisfy the same edges, so
+// a green result says "the lockfile's graph is met", not "the trees are identical".
+//
+// An importer's declared dependency the lockfile does not pin is a failure: that is the
+// package.json/lockfile drift `npm ci` refuses. Optional dependencies are skipped (a
+// platform mismatch drops them legitimately). A workspace link is judged by the member
+// directory's own manifest, not by the version the lockfile recorded for it: npm links the
+// directory as it is and `npm ci` never compares the two (socket.io's lockfile records
+// engine.io at 6.6.9 while the member is at 6.6.10).
+//
+// A required peer must be present and satisfy the dependent's declared range; its exact
+// version is reported, not judged. npm resolves a peer by where hoisting happened to place
+// the dependent, so a plugin hoisted to the root sees the root's typescript even when the
+// member that uses it pins another; nub resolves a peer from the dependent's own context.
+// Both meet the package's declared contract, and only the regular dependency graph is what
+// the lockfile pins. The walk starts from the dependent's real directory, so a peer nub
+// links beside a package in its store counts exactly as a hoisted one does.
+//
+// One tolerance, by construction of the store: npm's lockfile can place the same
+// name@version twice with different transitive resolutions (http-errors@1.6.3 under `send`
+// resolving statuses@1.4.0, under `serve-index` statuses@1.5.0). A content-addressed store
+// keys a package by name@version, so nub — like `pnpm import` — keeps one of those
+// resolutions for both placements. An edge whose version is what ANOTHER placement of the
+// same dependent resolves to is accepted and counted as collapsed; a version no placement
+// resolves to is a mismatch.
+//
+//   node tests/npm-corpus/check-tree.mjs <project-dir>
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+// Real path, so the walk below can tell "inside the project" from "outside" after every
+// package directory has been resolved through its symlinks (/tmp is one on macOS).
+const root = realpathSync(resolve(process.argv[2] ?? "."));
+const lock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8"));
+if (!lock.packages) {
+  console.error(`check-tree: lockfileVersion ${lock.lockfileVersion} carries no "packages" map`);
+  process.exit(2);
+}
+const packages = lock.packages;
+const readVersion = (file) => JSON.parse(readFileSync(file, "utf8")).version;
+
+// Importers are the root and every workspace member npm links at the root. A member entry
+// nothing links is a leftover from a renamed or removed package (socket.io's lockfile still
+// carries `packages/socket.io-clustered-engine`); npm does not install it, so nor does this.
+// A link whose target sits inside a node_modules directory is a package linking to itself
+// (puppeteer's lockfile has one under a nested browserslist), not a workspace.
+const linked = new Set(
+  Object.values(packages)
+    .filter((entry) => entry.link && entry.resolved && !entry.resolved.split("/").includes("node_modules"))
+    .map((entry) => entry.resolved),
+);
+const importers = Object.keys(packages).filter((key) => key === "" || linked.has(key));
+
+// The lockfile keys mirror the walk: <from>/node_modules/<name>, then each ancestor of <from>.
+function lockResolve(from, name) {
+  let dir = from;
+  for (;;) {
+    const key = dir === "" ? `node_modules/${name}` : `${dir}/node_modules/${name}`;
+    if (packages[key]) return { key, entry: packages[key] };
+    if (dir === "") return null;
+    const cut = dir.lastIndexOf("/");
+    dir = cut === -1 ? "" : dir.slice(0, cut);
+  }
+}
+// A workspace link's version is the member directory's, as installed; every other entry
+// carries its own.
+function lockVersion({ key, entry }) {
+  if (!entry.link) return { key, version: entry.version };
+  try {
+    return { key: entry.resolved, version: readVersion(join(root, entry.resolved, "package.json")) };
+  } catch {
+    return { key: entry.resolved, version: packages[entry.resolved]?.version };
+  }
+}
+// The subset of semver this needs: the ranges packages declare on their peers.
+function satisfies(version, range) {
+  const v = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/);
+  if (!v) return false;
+  const [maj, min, pat] = [Number(v[1]), Number(v[2]), Number(v[3])];
+  const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+  const parse = (t) => {
+    const m = t.match(/^(\d+|x|\*)(?:\.(\d+|x|\*))?(?:\.(\d+|x|\*))?/);
+    if (!m) return null;
+    const num = (x) => (x === undefined || x === "x" || x === "*" ? null : Number(x));
+    return [num(m[1]), num(m[2]), num(m[3])];
+  };
+  const clause = (c) => {
+    c = c.trim();
+    if (c === "" || c === "*" || c === "x") return true;
+    const hyphen = c.match(/^(\S+)\s+-\s+(\S+)$/);
+    if (hyphen) return clause(">=" + hyphen[1]) && clause("<=" + hyphen[2]);
+    return c.split(/\s+/).every((part) => {
+      const m = part.match(/^(\^|~|>=|<=|>|<|=)?v?(.+)$/);
+      const op = m[1] ?? "";
+      const p = parse(m[2]);
+      if (!p) return false;
+      const [a, b, d] = p;
+      const lo = [a ?? 0, b ?? 0, d ?? 0];
+      const cur = [maj, min, pat];
+      if (op === ">=") return cmp(cur, lo) >= 0;
+      if (op === ">") return cmp(cur, lo) > 0;
+      if (op === "<=") return cmp(cur, lo) <= 0;
+      if (op === "<") return cmp(cur, lo) < 0;
+      let hi;
+      if (op === "^") hi = a > 0 ? [a + 1, 0, 0] : b > 0 ? [0, b + 1, 0] : [0, 0, (d ?? 0) + 1];
+      else if (op === "~") hi = b === null ? [a + 1, 0, 0] : [a, b + 1, 0];
+      else if (b === null) hi = [a + 1, 0, 0];
+      else if (d === null) hi = [a, b + 1, 0];
+      else return cmp(cur, lo) === 0;
+      return cmp(cur, lo) >= 0 && cmp(cur, hi) < 0;
+    });
+  };
+  // "`>= 4.3.x`" is a common spelling: fold the space after an operator before splitting.
+  return range.replace(/([<>=~^]+)\s+/g, "$1").split("||").some(clause);
+}
+// The walk Node performs from `fromDir`, which must be a REAL directory: under nub's isolated
+// layout a package's dependencies and peers sit beside it in the store, not under the root.
+// The walk stops at the project root, and at the filesystem root for a store kept outside it.
+function diskResolve(fromDir, name) {
+  let dir = fromDir;
+  for (;;) {
+    const pkgDir = join(dir, "node_modules", name);
+    const manifest = join(pkgDir, "package.json");
+    if (existsSync(manifest)) {
+      try {
+        return { path: manifest, dir: realpathSync(pkgDir), version: readVersion(manifest) };
+      } catch (error) {
+        return { path: manifest, dir: pkgDir, version: undefined, error: error.message };
+      }
+    }
+    const parent = dirname(dir);
+    if (dir === root || parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// (dependent name@version, dependency name) → every version the lockfile resolves it to
+// across the dependent's placements; more than one means npm placed it twice.
+const placements = new Map();
+for (const key of Object.keys(packages)) {
+  const entry = packages[key];
+  if (key === "" || entry.link || !entry.version) continue;
+  const name = entry.name ?? key.slice(key.lastIndexOf("node_modules/") + "node_modules/".length);
+  const declared = [
+    ...Object.keys(entry.dependencies ?? {}),
+    ...Object.keys(entry.optionalDependencies ?? {}),
+    ...Object.keys(entry.peerDependencies ?? {}),
+  ];
+  for (const dep of declared) {
+    const pinned = lockResolve(key, dep);
+    if (!pinned) continue;
+    const id = `${name}@${entry.version}\0${dep}`;
+    if (!placements.has(id)) placements.set(id, new Set());
+    placements.get(id).add(lockVersion(pinned).version);
+  }
+}
+
+const missing = [];
+const mismatched = [];
+const unpinned = [];
+let collapsed = 0;
+let peersByContext = 0;
+let edges = 0;
+let nodes = 0;
+let optionalSkipped = 0;
+let transitiveUnpinned = 0;
+
+// Breadth-first over (lockfile node, real directory). Every importer is queued before any
+// package is processed, so a workspace member reached as another importer's dependency is
+// still checked as an importer — with its devDependencies — and only once.
+const queue = [];
+for (const importer of importers) {
+  try {
+    queue.push({ lockKey: importer, realDir: realpathSync(join(root, importer)), isImporter: true });
+  } catch {
+    missing.push(`${importer}: workspace directory absent`);
+  }
+}
+const seen = new Set();
+const enqueue = (lockKey, realDir) => queue.push({ lockKey, realDir, isImporter: false });
+
+// Every edge the lockfile records for `lockKey`, checked from `realDir`.
+function check(lockKey, realDir, isImporter) {
+  const id = `${lockKey}\0${realDir}`;
+  if (seen.has(id)) return;
+  seen.add(id);
+  nodes += 1;
+  const entry = packages[lockKey];
+  const where = lockKey === "" ? "." : lockKey;
+  const optional = new Set(Object.keys(entry.optionalDependencies ?? {}));
+  const peerMeta = entry.peerDependenciesMeta ?? {};
+  // A name declared as both a dependency and a peer is a peer: the package takes whichever
+  // copy its dependent context provides, and that is the contract judged here.
+  const declared = new Map();
+  for (const name of Object.keys(entry.dependencies ?? {})) declared.set(name, "dependency");
+  if (isImporter) for (const name of Object.keys(entry.devDependencies ?? {})) declared.set(name, "devDependency");
+  for (const name of Object.keys(entry.peerDependencies ?? {})) {
+    if (peerMeta[name]?.optional) declared.delete(name);
+    else declared.set(name, "peer");
+  }
+  for (const [name, kind] of declared) {
+    if (optional.has(name)) {
+      optionalSkipped += 1;
+      continue;
+    }
+    const pinned = lockResolve(lockKey, name);
+    if (!pinned) {
+      // npm's lockfile records every peer it installed; one it did not is the dependent's
+      // problem under npm too, and nothing here can say what version to expect.
+      if (kind === "peer" || !isImporter) transitiveUnpinned += 1;
+      else unpinned.push(`${where}: ${name} (${kind})`);
+      continue;
+    }
+    const want = lockVersion(pinned);
+    const have = diskResolve(realDir, name);
+    edges += 1;
+    if (!have) {
+      missing.push(`${where} → ${name}@${want.version ?? "?"} (${kind})`);
+      continue;
+    }
+    if (want.version && have.version !== want.version) {
+      const dependent = lockKey === "" ? null : `${entry.name ?? lockKey.slice(lockKey.lastIndexOf("node_modules/") + "node_modules/".length)}@${entry.version}`;
+      const elsewhere = dependent ? placements.get(`${dependent}\0${name}`) : undefined;
+      if (kind === "peer" && have.version && satisfies(have.version, entry.peerDependencies[name])) {
+        peersByContext += 1;
+      } else if (elsewhere && elsewhere.size > 1 && elsewhere.has(have.version)) {
+        collapsed += 1;
+      } else {
+        mismatched.push(`${where} → ${name}: lockfile ${want.version}, found ${have.version ?? have.error} at ${have.path}${kind === "peer" ? " (peer, out of range)" : ""}`);
+        continue;
+      }
+      // Continue the walk from the lockfile's node for this dependent: the disk copy is
+      // another placement of the same package, whose own edges the lockfile pins elsewhere.
+      const found = lockResolve("", name);
+      if (found && lockVersion(found).version === have.version) enqueue(found.key, have.dir);
+      continue;
+    }
+    enqueue(want.key, have.dir);
+  }
+}
+
+for (let i = 0; i < queue.length; i += 1) {
+  const { lockKey, realDir, isImporter } = queue[i];
+  check(lockKey, realDir, isImporter);
+}
+
+console.log(
+  `check-tree: ${importers.length} importer(s), ${nodes} package(s) reached over ${edges} lockfile edge(s); ` +
+    `${missing.length} missing, ${mismatched.length} at another version, ${unpinned.length} declared but unpinned` +
+    ` (skipped ${optionalSkipped} optional, ${transitiveUnpinned} unpinned transitive or peer; ${collapsed} collapsed placement(s), ${peersByContext} peer(s) resolved by context)`,
+);
+for (const line of missing) console.log(`  missing     ${line}`);
+for (const line of mismatched) console.log(`  mismatched  ${line}`);
+for (const line of unpinned) console.log(`  unpinned    ${line}`);
+process.exit(missing.length + mismatched.length + unpinned.length === 0 ? 0 : 1);

--- a/tests/npm-corpus/corpus.tsv
+++ b/tests/npm-corpus/corpus.tsv
@@ -1,0 +1,32 @@
+# repo	commit	node	what it exercises
+# One real npm-incumbent project per line, pinned to a commit whose package-lock.json
+# `npm ci` accepts. `node` is the version the project's own CI runs. Keep the columns
+# tab-separated; matrix.mjs and run.sh both read this file.
+promptfoo/promptfoo	eb18c53d1b74783069fa765a889a104fc67367c4	24	2381 packages; workspace with peer-dependency importers; lifecycle scripts
+lerna/lerna	0be4313641e4757b1b68fe8ac178187d131a9bc4	26	1939 packages; nested workspace members under a parent member's node_modules
+conwnet/github1s	2288a5fc153c1c38d49f5a304d23c4ef1b3af2d6	24	679 packages; single-package project
+lit/lit	2485edf2fa7445081f12e052d7e800944121a58f	24	2096 packages; large workspace, versionless workspace links
+louislam/dockge	f809ae192b571944ad773e9866d3e67064ae8043	22	724 packages; esbuild build scripts under the default trust list
+eclipse-theia/theia	7c303b1836421183d7013f0bd679a9a30ff0b5dc	24	1959 packages; node-gyp addons built by lifecycle scripts, member `prepare` hooks
+Redocly/redoc	8dc59a0e37dbf7d96b412b2aab0d488f65cb5678	24	1277 packages
+socketio/socket.io	1d4269cee88586f90d491e532ca6f212bd4ab2ae	24	1116 packages; workspace whose members appear in two lockfile sections
+Modernizr/Modernizr	612ec65ccdba311e8b1153b1076d18f0251943f6	24	837 packages; puppeteer browser download in postinstall
+avajs/ava	bbfd946322fdeca2b547a691d947fb4e18c0c67f	26	786 packages; multi-digest integrity strings
+meteor/meteor	02f4d27b1db832e7c1d02d26ec63c12c6671c4d2	24	356 packages
+mochajs/mocha	3a118405f375361f8084093dd85eaa89e79a5af7	24	620 packages; a tsconfig the PM must not reject
+apollographql/apollo-server	6193ea909389d61d10f893e6b66b8080ea201aa8	22	1107 packages; workspace
+puppeteer/puppeteer	f0dc34c9afd8e39d64805f61b08f306a25f7c56b	24	850 packages; workspace; browser download in postinstall
+usebruno/bruno	1622ee0c9dd2e2d56b27852c2366dccc0c382cf6	22.12	2168 packages; a member `prepare` that runs tsx over nub on the compat tier
+necolas/react-native-web	a9de220ba9e65bdea540fb5322ffb1da2b0bf442	20	single package on the compat tier
+axios/axios	b8d67bbbd6b381e1f4b1887e32686fcc89c5b0a8	26	612 packages
+nodejs/undici	b73952a4f74eff55c9bf03bdf0efabd2702986d1	24	635 packages
+graphql/graphql-js	3b9d3d4bc1d8c384569e002b51b92119aa1c4500	24	450 packages
+open-telemetry/opentelemetry-js	f62c392791a182f4c1b50a2fe0e41ecb1272772b	26	1511 packages; workspace
+jquery/jquery	5ed303d01568dfad361c4de086d28e04ba0147f5	20	734 packages on the compat tier
+josdejong/mathjs	8d214e050a0acb9f132405d55a96b683fa7b6324	22	905 packages
+moment/luxon	f427515a38f6a671f8de663e6bcc040ed81f114e	22	724 packages
+motdotla/dotenv	2fc7eac8ad77cbd5f7814355c7fa352dbcf3c358	24	606 packages
+hubotio/hubot	1a46897420780674ff8cfc7665c22d5bf33295af	24	82 packages
+hakimel/reveal.js	807b43097da554de4dba6d020b07f3f110fb766d	22	180 packages
+commitizen/cz-cli	1a8c49c02c9d52d1b4ef8cdabefb538088ddea03	24	761 packages
+rollup/rollup	02340ecdd312b0e4db8d1dc9446c0edaffedec68	24	1048 packages; a postinstall that patches transitive packages at the root

--- a/tests/npm-corpus/expected-failures.txt
+++ b/tests/npm-corpus/expected-failures.txt
@@ -1,0 +1,20 @@
+# Known-red corpus entries: "<owner/repo> <reason>". Same discipline as the other
+# harnesses: this list must SHRINK. A listed repo that installs and checks clean
+# fails the run (XPASS-STALE), so the green flip is recorded by deleting its line
+# in the same commit as the fix.
+
+# rollup's postinstall runs patch-package against packages it does not depend on
+# directly (`@types/rimraf` and one more). npm hoists them to the root; nub's
+# isolated layout keeps only direct dependencies there, so the patch targets are
+# absent. Installs with `node-linker=hoisted` in the project's .npmrc.
+rollup/rollup postinstall patch-package expects transitive packages hoisted to the root
+
+# A peer npm auto-installs and marks `peer: true`, reached only through a transitive
+# package's peer edge, is pruned as unreachable; and with no satisfying ancestor a peer
+# resolves to the newest copy in the graph or an out-of-range ancestor copy where the
+# lockfile places a satisfying one. Fixed in #923; these lines go with it.
+avajs/ava react-dom pruned under react-element-to-jsx-string; eslint-plugin-react gets an out-of-range eslint (#923)
+motdotla/dotenv react-dom pruned under react-element-to-jsx-string (#923)
+axios/axios @types/node pruned under cosmiconfig-typescript-loader (#923)
+promptfoo/promptfoo search-insights pruned under the algolia autocomplete plugin (#923)
+puppeteer/puppeteer typescript out of range under @typescript-eslint/utils (#923), and browserslist missing beside a nested @babel/helper-compilation-targets

--- a/tests/npm-corpus/matrix.mjs
+++ b/tests/npm-corpus/matrix.mjs
@@ -1,0 +1,27 @@
+// Emits corpus.tsv as a GitHub Actions matrix, `{ include: [{repo, commit, node}, ...] }`.
+// Any arguments are `owner/repo` names to keep (comma- or space-separated); none keeps all.
+//
+//   node tests/npm-corpus/matrix.mjs
+//   node tests/npm-corpus/matrix.mjs mochajs/mocha,avajs/ava
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const keep = new Set(process.argv.slice(2).flatMap((a) => a.split(/[,\s]+/)).filter(Boolean));
+const include = readFileSync(join(here, "corpus.tsv"), "utf8")
+  .split("\n")
+  .filter((line) => line.trim() && !line.startsWith("#"))
+  .map((line) => {
+    const [repo, commit, node] = line.split("\t");
+    if (!/^[\w.-]+\/[\w.-]+$/.test(repo) || !/^[0-9a-f]{40}$/.test(commit) || !/^\d+(\.\d+)*$/.test(node)) {
+      throw new Error(`corpus.tsv: malformed line: ${JSON.stringify(line)}`);
+    }
+    return { repo, commit, node };
+  })
+  .filter((entry) => keep.size === 0 || keep.has(entry.repo));
+if (keep.size > 0 && include.length !== keep.size) {
+  const known = new Set(include.map((e) => e.repo));
+  throw new Error(`not in corpus.tsv: ${[...keep].filter((r) => !known.has(r)).join(", ")}`);
+}
+process.stdout.write(`${JSON.stringify({ include })}\n`);

--- a/tests/npm-corpus/run.sh
+++ b/tests/npm-corpus/run.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# npm-incumbent corpus: real projects whose package manager is npm, pinned by commit in
+# corpus.tsv, frozen-installed under nub on a cold store from their own package-lock.json,
+# then checked against that lockfile (check-tree.mjs). The verdict per project is
+# "installs and satisfies its lockfile", which is the contract `npm ci` gives them today.
+#
+#   PASS         install exit 0, lifecycle scripts included, and the tree checks clean
+#   FAIL         nub fails where `npm ci` succeeds — a nub defect
+#   XFAIL        listed in expected-failures.txt (a known, tracked red); passing is XPASS-STALE
+#   XFAIL-ENV    `npm ci` fails on this runner too, so the red is the environment or the pin
+#
+# Usage: run.sh <path-to-nub> [owner/repo ...]      (no repos = the whole corpus)
+# Env:   CONTROL=on-failure|always|never  run `npm ci` on a second, pristine checkout of the
+#                                         same commit with a cold cache. on-failure (default)
+#                                         classifies a red; always also records the wall-clock
+#                                         of both installs.
+#        WORK=<dir>   clone and install here (default: a fresh temp dir, removed on success)
+#        KEEP=1       keep the work dir
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NUB_ARG="${1:?usage: run.sh <path-to-nub> [owner/repo ...]}"
+shift
+NUB="$(cd "$(dirname "$NUB_ARG")" && pwd)/$(basename "$NUB_ARG")"
+[ -x "$NUB" ] || { echo "error: nub binary not executable: $NUB" >&2; exit 2; }
+CONTROL="${CONTROL:-on-failure}"
+case "$CONTROL" in on-failure|always|never) ;; *) echo "error: CONTROL must be on-failure, always or never" >&2; exit 2 ;; esac
+KEEP="${KEEP:-0}"
+CREATED_WORK=0
+if [ -z "${WORK:-}" ]; then
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/nub-npm-corpus.XXXXXX")"
+  CREATED_WORK=1
+fi
+cleanup() {
+  local code=$?
+  if [ "$CREATED_WORK" -eq 1 ] && [ "$KEEP" = "0" ] && [ "$code" -eq 0 ]; then rm -rf "$WORK"
+  elif [ "$code" -ne 0 ]; then echo "(work dir preserved for inspection at $WORK)"; fi
+}
+trap cleanup EXIT
+TIMEOUT=()
+command -v timeout >/dev/null 2>&1 && TIMEOUT=(timeout 1500)
+
+# Selection: the arguments, or every non-comment line of corpus.tsv. Names are matched
+# exactly; one that matches no line is an error rather than a silently empty run.
+selected=("$@")
+entries=()
+matched=()
+while IFS=$'\t' read -r repo commit node _notes; do
+  if [ -z "$repo" ] || [ "${repo:0:1}" = "#" ]; then continue; fi
+  if [ "${#selected[@]}" -gt 0 ]; then
+    hit=0; for s in "${selected[@]}"; do [ "$s" = "$repo" ] && hit=1; done
+    [ "$hit" -eq 1 ] || continue
+  fi
+  entries+=("$repo"$'\t'"$commit"$'\t'"$node")
+  matched+=("$repo")
+done < "$HERE/corpus.tsv"
+for s in "${selected[@]}"; do
+  hit=0; for m in "${matched[@]}"; do [ "$s" = "$m" ] && hit=1; done
+  [ "$hit" -eq 1 ] || { echo "error: not in corpus.tsv: $s" >&2; exit 2; }
+done
+[ "${#entries[@]}" -gt 0 ] || { echo "error: nothing selected from corpus.tsv" >&2; exit 2; }
+
+expected_reason() { # expected_reason <repo> → prints the reason, exits 1 if unlisted
+  grep -v '^#' "$HERE/expected-failures.txt" | awk -v r="$1" '$1 == r { $1 = ""; sub(/^ /, ""); print; found = 1 } END { exit !found }'
+}
+elapsed() { echo $(( $(date +%s) - $1 )); }
+
+echo "== npm corpus: ${#entries[@]} project(s), nub $("$NUB" --version 2>/dev/null | head -1), node $(node --version), control=$CONTROL =="
+fails=0; stale=0; envreds=0; passes=0; xfails=0
+RESULTS=()
+for entry in "${entries[@]}"; do
+  IFS=$'\t' read -r repo commit node <<< "$entry"
+  name="${repo//\//__}"
+  dir="$WORK/$name"
+  rm -rf "$dir"; mkdir -p "$dir"
+  xdg="$WORK/$name.home"
+  export XDG_DATA_HOME="$xdg/data" XDG_CACHE_HOME="$xdg/cache" npm_config_cache="$xdg/npm-cache" CI=1
+  echo
+  echo "-- $repo @ ${commit:0:12} (their CI runs node $node)"
+  if ! ( cd "$dir" && git init -q && git remote add origin "https://github.com/$repo.git" \
+         && git fetch -q --depth 1 origin "$commit" && git checkout -q FETCH_HEAD ) > "$WORK/$name.clone.log" 2>&1; then
+    echo "  FAIL  $repo — clone at $commit failed:"; tail -5 "$WORK/$name.clone.log" | sed 's/^/        /'
+    fails=$((fails + 1)); RESULTS+=("$repo|FAIL|clone"); continue
+  fi
+  if [ ! -f "$dir/package-lock.json" ]; then
+    echo "  FAIL  $repo — no package-lock.json at $commit"; fails=$((fails + 1)); RESULTS+=("$repo|FAIL|no lockfile"); continue
+  fi
+
+  nub_log="$WORK/$name.nub.log"
+  t0=$(date +%s)
+  ( cd "$dir" && "${TIMEOUT[@]}" "$NUB" install --frozen-lockfile ) > "$nub_log" 2>&1; rc=$?
+  nub_s=$(elapsed "$t0")
+  stage="install"
+  if [ "$rc" -eq 0 ]; then
+    stage="check-tree"
+    node "$HERE/check-tree.mjs" "$dir" >> "$nub_log" 2>&1; rc=$?
+  fi
+  summary="$(grep -oE 'check-tree: .*' "$nub_log" | tail -1)"
+
+  npm_note=""
+  if [ "$CONTROL" = "always" ] || { [ "$CONTROL" = "on-failure" ] && [ "$rc" -ne 0 ]; }; then
+    if command -v npm >/dev/null 2>&1; then
+      # A second checkout of the pinned commit: nub's lifecycle scripts may have written into
+      # the first one, and a residue that fails npm would read as an environment red.
+      npm_log="$WORK/$name.npm.log"
+      npm_dir="$dir.npm"
+      rm -rf "$npm_dir"
+      if git -C "$dir" worktree add -q --detach "$npm_dir" HEAD > "$npm_log" 2>&1; then
+        t1=$(date +%s)
+        ( cd "$npm_dir" && "${TIMEOUT[@]}" npm ci ) >> "$npm_log" 2>&1; npm_rc=$?
+        npm_s=$(elapsed "$t1")
+        if [ "$npm_rc" -eq 0 ]; then npm_note="npm ci ${npm_s}s"; else npm_note="npm ci FAILED (exit $npm_rc, ${npm_s}s)"; fi
+      else
+        # No control checkout means no control: the nub verdict stands on its own.
+        npm_rc=-1; npm_note="control checkout failed, no control"
+      fi
+    else
+      npm_rc=-1; npm_note="npm not on PATH, no control"
+    fi
+  else
+    npm_rc=-1
+  fi
+
+  reason="$(expected_reason "$repo")" && listed=1 || listed=0
+  if [ "$rc" -eq 0 ]; then
+    if [ "$listed" -eq 1 ]; then
+      echo "  XPASS-STALE $repo — now passes; remove its line from expected-failures.txt: $reason"
+      stale=$((stale + 1)); RESULTS+=("$repo|XPASS-STALE|nub ${nub_s}s${npm_note:+, $npm_note}")
+    else
+      echo "  PASS  $repo — nub ${nub_s}s${npm_note:+, $npm_note}; $summary"
+      passes=$((passes + 1)); RESULTS+=("$repo|PASS|nub ${nub_s}s${npm_note:+, $npm_note}")
+    fi
+  elif [ "$listed" -eq 1 ]; then
+    echo "  XFAIL $repo — expected: $reason"
+    xfails=$((xfails + 1)); RESULTS+=("$repo|XFAIL|$reason")
+  elif [ "$npm_rc" -gt 0 ]; then
+    echo "  XFAIL-ENV $repo — nub failed at $stage (exit $rc) and $npm_note here too; not counted. nub tail:"
+    tail -8 "$nub_log" | sed 's/^/        /'; echo "        npm tail:"; tail -5 "$npm_log" | sed 's/^/        /'
+    envreds=$((envreds + 1)); RESULTS+=("$repo|XFAIL-ENV|$stage, $npm_note")
+  else
+    echo "  FAIL  $repo — $stage failed (exit $rc, nub ${nub_s}s${npm_note:+, $npm_note}); tail:"
+    tail -25 "$nub_log" | sed 's/^/        /'
+    fails=$((fails + 1)); RESULTS+=("$repo|FAIL|$stage${npm_note:+, $npm_note}")
+  fi
+  [ "$KEEP" = "1" ] || rm -rf "$dir/node_modules" "$dir.npm" "$xdg"
+done
+
+echo
+echo "== summary =="
+for r in "${RESULTS[@]}"; do IFS='|' read -r repo verdict note <<< "$r"; printf "  %-12s %-36s %s\n" "$verdict" "$repo" "$note"; done
+echo
+if [ "$fails" -gt 0 ] || [ "$stale" -gt 0 ]; then
+  echo "RESULT: FAIL ($fails nub failure(s), $stale stale expected-failure entry/entries; $passes passed, $xfails expected red, $envreds environment red)"
+  exit 1
+fi
+echo "RESULT: OK ($passes passed, $xfails expected red, $envreds environment red)"


### PR DESCRIPTION
Adds `tests/npm-corpus/`: 28 real npm-incumbent projects pinned by commit, frozen-installed under nub on a cold store and checked against their own `package-lock.json` (every importer's declared dependencies present at the pinned version, by Node's `node_modules` walk, so npm's hoisted layout and nub's isolated one meet one contract). `npm ci` runs on the same clone to classify a red; `expected-failures.txt` carries the one known red (rollup's patch-package postinstall).

`npm-corpus.yml` builds nub once and fans out one job per project on its own Node version: push to main on the PM surface, opt-in PR runs, a nightly that also times `npm ci`, and on demand.