### PR TITLE
pm: record the peer each npm lockfile placement resolves to as a graph edge

### DIFF
--- a/tests/npm-corpus/expected-failures.txt
+++ b/tests/npm-corpus/expected-failures.txt
@@ -8,13 +8,3 @@
 # isolated layout keeps only direct dependencies there, so the patch targets are
 # absent. Installs with `node-linker=hoisted` in the project's .npmrc.
 rollup/rollup postinstall patch-package expects transitive packages hoisted to the root
-
-# A peer npm auto-installs and marks `peer: true`, reached only through a transitive
-# package's peer edge, is pruned as unreachable; and with no satisfying ancestor a peer
-# resolves to the newest copy in the graph or an out-of-range ancestor copy where the
-# lockfile places a satisfying one. Fixed in #923; these lines go with it.
-avajs/ava react-dom pruned under react-element-to-jsx-string; eslint-plugin-react gets an out-of-range eslint (#923)
-motdotla/dotenv react-dom pruned under react-element-to-jsx-string (#923)
-axios/axios @types/node pruned under cosmiconfig-typescript-loader (#923)
-promptfoo/promptfoo search-insights pruned under the algolia autocomplete plugin (#923)
-puppeteer/puppeteer typescript out of range under @typescript-eslint/utils (#923), and browserslist missing beside a nested @babel/helper-compilation-targets

--- a/vendor/aube/crates/aube-lockfile/src/npm/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/read.rs
@@ -81,11 +81,32 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
     // the target path entry carries the package metadata. Skip the target-path
     // record during the main loop and let the link entry synthesize a local
     // package from it.
+    //
+    // One more shape, which is neither: a `link` whose target is a registry
+    // package inside `node_modules`. npm writes it to point a nested
+    // dependent's peer at the copy above it — puppeteer's lockfile has
+    // `…/browserslist/node_modules/browserslist` linking back to
+    // `…/browserslist` for update-browserslist-db's peer. The target is a
+    // registry package and stays one; the link is only an install path
+    // that resolves to it, so it creates no package of its own.
+    let pointer_link_target = |entry: &super::raw::RawNpmPackage| -> Option<String> {
+        if !entry.link {
+            return None;
+        }
+        let target = entry.resolved.as_deref()?;
+        if !target.split('/').any(|segment| segment == "node_modules") {
+            return None;
+        }
+        let target_entry = raw.packages.get(target)?;
+        (!target_entry.link && target_entry.version.is_some()).then(|| target.to_string())
+    };
     let link_targets: BTreeSet<String> = raw
         .packages
         .values()
+        .filter(|entry| pointer_link_target(entry).is_none())
         .filter_map(|entry| entry.link.then(|| entry.resolved.clone()).flatten())
         .collect();
+    let mut pointer_links: Vec<(String, String)> = Vec::new();
 
     // Map each install_path to the locked dep_path it resolves to. We need
     // this for the nested-resolution walk, including local/workspace links
@@ -124,6 +145,10 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
             .as_ref()
             .filter(|real| real.as_str() != install_name.as_str())
             .cloned();
+        if let Some(target) = pointer_link_target(entry) {
+            pointer_links.push((install_path.clone(), target));
+            continue;
+        }
         let (package_entry, version, dep_path, local_source) = if entry.link {
             let target = entry.resolved.as_ref().ok_or_else(|| {
                 Error::parse(
@@ -297,6 +322,18 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
     // npm.rs's data model doesn't express that, and in practice npm
     // dedupes only when the transitives match anyway.
     type ResolvedDepMap = BTreeMap<String, String>;
+    // A pointer link resolves to whatever its target resolves to, whichever
+    // of the two the map visited first.
+    for (install_path, target) in pointer_links {
+        if let Some(target_info) = install_path_info.get(&target) {
+            let info = InstallPathInfo {
+                name: target_info.name.clone(),
+                dep_path: target_info.dep_path.clone(),
+            };
+            install_path_info.insert(install_path, info);
+        }
+    }
+
     let mut resolved_by_dep_path: BTreeMap<String, (ResolvedDepMap, ResolvedDepMap)> =
         BTreeMap::new();
     for (install_path, entry) in &raw.packages {
@@ -355,6 +392,46 @@ pub fn parse(path: &Path, manifest: &aube_manifest::PackageJson) -> Result<Lockf
                 resolved.insert(dep_name.clone(), tail.clone());
                 if is_optional {
                     resolved_optional.insert(dep_name.clone(), tail);
+                }
+            }
+        }
+        // Peers, by placement. npm records the copy of a peer each dependent
+        // sees — auto-installed and hoisted to the root, or nested beside the
+        // dependent when the root's copy does not satisfy it — and ties it to
+        // no regular dependency edge. The graph carries that placement as a
+        // dependency edge so two downstream passes see it. `filter_graph`'s
+        // reachability walk keeps a peer-only package alive: `react-dom`
+        // reached solely through a transitive package's peer edge was pruned,
+        // and the package died at runtime with `Cannot find package`. And
+        // `apply_peer_contexts` takes the recorded copy when no ancestor
+        // provides a satisfying one, where it used to fall back to the newest
+        // version in the graph or to an ancestor's out-of-range copy
+        // (eslint-plugin-react was handed xo's eslint 10 with npm's nested
+        // eslint 9 sitting in the lockfile). An ancestor that satisfies the
+        // range still wins, as it does for every lockfile shape. The range is
+        // deliberately not added to `declared`: the npm writer emits only
+        // declared names under `dependencies`, so the round trip stays
+        // byte-identical. An optional peer (`peerDependenciesMeta`) is an
+        // optional edge, so a provider that is otherwise only optionally
+        // reachable keeps that classification and platform pruning can still
+        // drop it.
+        for peer_name in package_entry.peer_dependencies.keys() {
+            if resolved.contains_key(peer_name) {
+                continue;
+            }
+            if let Some(target_install_path) =
+                crate::npm::layout::resolve_nested(lookup_path, peer_name, &install_path_info)
+                && let Some(target_info) = install_path_info.get(&target_install_path)
+            {
+                let tail =
+                    crate::npm::dep_path_tail(&target_info.name, &target_info.dep_path).to_string();
+                let optional = package_entry
+                    .peer_dependencies_meta
+                    .get(peer_name)
+                    .is_some_and(|meta| meta.optional);
+                resolved.insert(peer_name.clone(), tail.clone());
+                if optional {
+                    resolved_optional.insert(peer_name.clone(), tail);
                 }
             }
         }

--- a/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/tests.rs
@@ -2390,6 +2390,282 @@ fn test_parse_peer_dependencies() {
     );
 }
 
+/// npm records the copy of a peer each dependent sees — hoisted to the
+/// root when it satisfies, nested beside the dependent when the root's
+/// copy does not — and never through a regular dependency edge. The
+/// reader carries that placement as a dependency edge: `react-dom`,
+/// reached only through a transitive package's peer, stays reachable, and
+/// the peer pass takes the nested `eslint` 9 instead of the root's 10.
+#[test]
+fn test_parse_records_peer_placement_as_dependency_edge() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "peer-placement",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "peer-placement",
+                    "version": "1.0.0",
+                    "dependencies": { "tcompare": "^15.0.0", "eslint": "^10.0.0", "plugin": "^1.0.0" }
+                },
+                "node_modules/tcompare": {
+                    "version": "15.0.0",
+                    "dependencies": { "react-element-to-jsx-string": "^15.0.0" }
+                },
+                "node_modules/react-element-to-jsx-string": {
+                    "version": "15.0.0",
+                    "peerDependencies": { "react": "^18.0.0", "react-dom": "^18.0.0", "absent": "*", "extra": "*" },
+                    "peerDependenciesMeta": { "extra": { "optional": true } }
+                },
+                "node_modules/extra": { "version": "1.0.0", "peer": true },
+                "node_modules/react": { "version": "18.3.1", "peer": true },
+                "node_modules/react-dom": {
+                    "version": "18.3.1",
+                    "peer": true,
+                    "peerDependencies": { "react": "^18.3.1" }
+                },
+                "node_modules/eslint": { "version": "10.0.0" },
+                "node_modules/plugin": {
+                    "version": "1.0.0",
+                    "peerDependencies": { "eslint": "^9.0.0" }
+                },
+                "node_modules/plugin/node_modules/eslint": { "version": "9.0.0", "peer": true }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let jsx = &graph.packages["react-element-to-jsx-string@15.0.0"];
+    assert_eq!(
+        jsx.dependencies,
+        [
+            ("extra".to_string(), "1.0.0".to_string()),
+            ("react".to_string(), "18.3.1".to_string()),
+            ("react-dom".to_string(), "18.3.1".to_string()),
+        ]
+        .into_iter()
+        .collect::<BTreeMap<_, _>>(),
+        "hoisted peers are recorded by placement; an unplaced one is not invented"
+    );
+    assert_eq!(
+        jsx.optional_dependencies,
+        [("extra".to_string(), "1.0.0".to_string())]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+        "an optional peer is an optional edge"
+    );
+    assert!(
+        jsx.declared_dependencies.is_empty(),
+        "a placed peer carries no declared range"
+    );
+    assert_eq!(
+        graph.packages["plugin@1.0.0"]
+            .dependencies
+            .get("eslint")
+            .map(String::as_str),
+        Some("9.0.0"),
+        "the nested copy beside the dependent wins over the root's"
+    );
+
+    // The placement is a graph edge, not a declared dependency: the
+    // re-emitted entry lists the peer under `peerDependencies` only.
+    let out = tempfile::NamedTempFile::new().unwrap();
+    let manifest = aube_manifest::PackageJson {
+        name: Some("peer-placement".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [
+            ("tcompare".to_string(), "^15.0.0".to_string()),
+            ("eslint".to_string(), "^10.0.0".to_string()),
+            ("plugin".to_string(), "^1.0.0".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+    write(out.path(), &graph, &manifest).unwrap();
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.path()).unwrap()).unwrap();
+    let entry = &written["packages"]["node_modules/react-element-to-jsx-string"];
+    assert!(
+        entry.get("dependencies").is_none() && entry.get("optionalDependencies").is_none(),
+        "a placed peer must not be re-emitted as a dependency; got {entry}"
+    );
+    assert_eq!(entry["peerDependencies"]["react-dom"], "^18.0.0");
+    // npm flags a package every path reaches through a peer edge; a root
+    // dependency and a package below it are not flagged.
+    for key in [
+        "node_modules/react",
+        "node_modules/react-dom",
+        "node_modules/extra",
+    ] {
+        assert_eq!(written["packages"][key]["peer"], true, "{key} is peer-only");
+    }
+    for key in [
+        "node_modules/eslint",
+        "node_modules/tcompare",
+        "node_modules/react-element-to-jsx-string",
+    ] {
+        assert!(
+            written["packages"][key].get("peer").is_none(),
+            "{key} is not peer-only"
+        );
+    }
+    assert_eq!(
+        written["packages"]["node_modules/plugin/node_modules/eslint"]["peer"],
+        true
+    );
+}
+
+/// A lockfile real npm wrote for a project whose only peer (`react`,
+/// under `react-dom` and `react-redux`) npm auto-installed and flagged
+/// `peer: true` must come back byte-identical: the flag is recomputed
+/// from reachability, and the peer edge the reader records stays out of
+/// every `dependencies` section.
+#[test]
+fn test_write_byte_identical_to_native_npm_with_peer_flags() {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/npm-native-peer.json");
+    let original = std::fs::read_to_string(&fixture)
+        .unwrap()
+        .replace("\r\n", "\n");
+    let graph = parse(&fixture).unwrap();
+    let manifest = aube_manifest::PackageJson {
+        name: Some("aube-lockfile-peer-flags".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: [("react-dom".to_string(), "18.3.1".to_string())]
+            .into_iter()
+            .collect(),
+        dev_dependencies: [("react-redux".to_string(), "9.2.0".to_string())]
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    };
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    write(tmp.path(), &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(tmp.path()).unwrap();
+    if written != original {
+        panic!(
+            "npm writer drifted from native npm output.\n\n--- expected ---\n{original}\n--- got ---\n{written}"
+        );
+    }
+}
+
+/// The root's own declared peer, and a workspace member's, are entered
+/// on their importers as production direct deps — the shape the resolver
+/// seeds under auto-install-peers — but real npm flags the providers
+/// `peer: true`, because no dependency edge reaches them. Lockfile from
+/// npm 11.19.0 for a root with `peerDependencies: { react }` and a member
+/// with `peerDependencies: { react-dom }`, and nothing else declared: every
+/// package in it carries the flag, and the round trip keeps each one.
+#[test]
+fn test_write_byte_identical_to_native_npm_with_importer_peers() {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/npm-native-root-peer.json");
+    let original = std::fs::read_to_string(&fixture)
+        .unwrap()
+        .replace("\r\n", "\n");
+    let graph = parse(&fixture).unwrap();
+    let manifest: aube_manifest::PackageJson = serde_json::from_str(
+        r#"{
+            "name": "root-peer",
+            "version": "1.0.0",
+            "workspaces": ["packages/*"],
+            "peerDependencies": { "react": "18.3.1" }
+        }"#,
+    )
+    .unwrap();
+    // Rewritten in place, as an install rewrites the project's lockfile:
+    // the writer keeps the existing file's root placements.
+    let dir = tempfile::tempdir().unwrap();
+    let lock = dir.path().join("package-lock.json");
+    std::fs::copy(&fixture, &lock).unwrap();
+    write(&lock, &graph, &manifest).unwrap();
+    let written = std::fs::read_to_string(&lock).unwrap();
+    if written != original {
+        panic!(
+            "npm writer drifted from native npm output.\n\n--- expected ---\n{original}\n--- got ---\n{written}"
+        );
+    }
+}
+
+/// npm can record a package linked to itself one level down —
+/// puppeteer's lockfile carries `…/browserslist/node_modules/browserslist`
+/// as a `link` back to `…/browserslist`. The registry package must still
+/// be registered as such, with its dependency resolved to it, rather than
+/// be taken for a local source.
+#[test]
+fn test_parse_self_link_under_a_registry_package() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let content = r#"{
+            "name": "self-link",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "self-link",
+                    "version": "1.0.0",
+                    "dependencies": { "a": "^1.0.0" }
+                },
+                "node_modules/a": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/a/-/a-1.0.0.tgz",
+                    "integrity": "sha512-a",
+                    "dependencies": { "b": "^4.0.0" }
+                },
+                "node_modules/a/node_modules/b": {
+                    "version": "4.28.8",
+                    "resolved": "https://registry.npmjs.org/b/-/b-4.28.8.tgz",
+                    "integrity": "sha512-b"
+                },
+                "node_modules/a/node_modules/b/node_modules/b": {
+                    "resolved": "node_modules/a/node_modules/b",
+                    "link": true
+                },
+                "node_modules/a/node_modules/b/node_modules/c": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/c/-/c-1.0.0.tgz",
+                    "integrity": "sha512-c",
+                    "peerDependencies": { "b": ">=4.0.0" }
+                }
+            }
+        }"#;
+    std::fs::write(tmp.path(), content).unwrap();
+
+    let graph = parse(tmp.path()).unwrap();
+    let b = graph.packages.get("b@4.28.8").unwrap_or_else(|| {
+        panic!(
+            "b@4.28.8 missing; packages: {:?}",
+            graph.packages.keys().collect::<Vec<_>>()
+        )
+    });
+    assert!(
+        b.local_source.is_none(),
+        "b is a registry package: {:?}",
+        b.local_source
+    );
+    assert_eq!(b.integrity.as_deref(), Some("sha512-b"));
+    assert_eq!(
+        graph.packages["a@1.0.0"]
+            .dependencies
+            .get("b")
+            .map(String::as_str),
+        Some("4.28.8")
+    );
+    // The link is what a nested dependent's peer resolves through.
+    assert_eq!(
+        graph.packages["c@1.0.0"]
+            .dependencies
+            .get("b")
+            .map(String::as_str),
+        Some("4.28.8")
+    );
+    assert!(
+        !graph.packages.keys().any(|k| k.starts_with("b@link")),
+        "no local package is synthesized for the pointer: {:?}",
+        graph.packages.keys().collect::<Vec<_>>()
+    );
+}
+
 /// Packages without peer fields keep both maps empty — guard
 /// against accidental defaulting to `optional: true` or spurious
 /// keys showing up in the LockedPackage from serde leak paths.

--- a/vendor/aube/crates/aube-lockfile/src/npm/write.rs
+++ b/vendor/aube/crates/aube-lockfile/src/npm/write.rs
@@ -72,6 +72,12 @@ struct WriteNpmPackage<'a> {
     link: bool,
     dev: bool,
     optional: bool,
+    /// npm `peer: true` — every path from the root to this package
+    /// crosses a peer edge, i.e. it is installed only because something
+    /// declares it as a peer. Recomputed from reachability like `dev` and
+    /// `optional`, over the peer edges the reader records by placement
+    /// and the peer pass merges into `dependencies`.
+    peer: bool,
     /// npm `bundleDependencies: ["name", …]` — a JSON array, so it
     /// sorts with the non-object scalars (at `b`, before `cpu`).
     /// Round-trip fidelity for packages declaring bundled deps.
@@ -169,6 +175,9 @@ impl Serialize for WriteNpmPackage<'_> {
         }
         if !self.os.is_empty() {
             map.serialize_entry("os", &self.os)?;
+        }
+        if self.peer {
+            map.serialize_entry("peer", &true)?;
         }
         // `workspaces` is the one key whose BUCKET depends on its value,
         // because `json-stringify-nice` sorts on the runtime type and npm
@@ -350,6 +359,72 @@ pub fn write(
             .or_insert(pkg);
     }
 
+    // Resolve each workspace member's identity (name/version/peers).
+    // A `LocalSource::Link` package exists only when the graph was
+    // *read* from an npm lockfile (the reader synthesizes it from the
+    // `node_modules/<name>: {link:true}` pair). On a fresh resolve from
+    // package.json there is no such package, so recover the member's
+    // name/version/peers from its own `package.json` on disk — the same
+    // best-effort disk read the pnpm and bun writers use. Without this
+    // fallback every member importer + its child deps were dropped and
+    // `npm ci` rejected the lockfile with `Missing: <member> from lock
+    // file`.
+    // Pre-read every member's `package.json` once, up front, so the
+    // borrowed name/version/peer strings live as long as `packages`
+    // (the `WriteNpmPackage` arena borrows them). Only read for importers
+    // without a `LocalSource::Link` package — i.e. a fresh resolve.
+    let project_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let member_manifests: BTreeMap<&str, aube_manifest::PackageJson> = graph
+        .importers
+        .keys()
+        .filter(|p| p.as_str() != ".")
+        .filter(|p| workspace_package_for_importer(graph, p).is_none())
+        .map(|p| {
+            let m =
+                aube_manifest::PackageJson::from_path(&project_dir.join(p).join("package.json"))
+                    .unwrap_or_default();
+            (p.as_str(), m)
+        })
+        .collect();
+
+    // A required peer the root or a member declares, and nothing else
+    // provides, is entered on its importer as a production direct dep —
+    // the shape the resolver seeds under auto-install-peers, and the one
+    // the freshness check compares the manifest against. npm flags such a
+    // provider `peer: true` all the same: no dependency edge reaches it.
+    // Recognized by its shape — a production direct dep whose specifier is
+    // the importer's declared peer range and that no dependency section
+    // declares — since `DirectDep` carries no provenance.
+    let synthesized_peer = |importer_path: &str, dep: &DirectDep| -> bool {
+        if dep.dep_type != DepType::Production {
+            return false;
+        }
+        let (peer_range, declared) = if importer_path == "." {
+            (
+                manifest.peer_dependencies.get(&dep.name),
+                manifest.dependencies.contains_key(&dep.name)
+                    || manifest.dev_dependencies.contains_key(&dep.name)
+                    || manifest.optional_dependencies.contains_key(&dep.name),
+            )
+        } else if let Some(pkg) = workspace_package_for_importer(graph, importer_path) {
+            (
+                pkg.peer_dependencies.get(&dep.name),
+                pkg.declared_dependencies.contains_key(&dep.name)
+                    || pkg.optional_dependencies.contains_key(&dep.name),
+            )
+        } else if let Some(m) = member_manifests.get(importer_path) {
+            (
+                m.peer_dependencies.get(&dep.name),
+                m.dependencies.contains_key(&dep.name)
+                    || m.dev_dependencies.contains_key(&dep.name)
+                    || m.optional_dependencies.contains_key(&dep.name),
+            )
+        } else {
+            return false;
+        };
+        !declared && peer_range.is_some_and(|range| dep.specifier.as_deref() == Some(range))
+    };
+
     // Compute reachability for dev/optional flags, matching npm's
     // path-based semantics: a package is `dev: true` iff *every* path
     // from the root crosses a dev edge, `optional: true` iff every
@@ -363,17 +438,51 @@ pub fn write(
         .values()
         .flat_map(|deps| deps.iter().cloned())
         .collect();
-    let any_reach = reachable_without(&canonical, &all_roots, &[]);
-    let non_dev_reach = reachable_without(&canonical, &all_roots, &[DepType::Dev]);
-    let non_opt_reach = reachable_without(&canonical, &all_roots, &[DepType::Optional]);
-    let prod_reach = reachable_without(&canonical, &all_roots, &[DepType::Dev, DepType::Optional]);
+    let any_reach = reachable_without(&canonical, &all_roots, &[], true);
+    let non_dev_reach = reachable_without(&canonical, &all_roots, &[DepType::Dev], true);
+    let non_opt_reach = reachable_without(&canonical, &all_roots, &[DepType::Optional], true);
+    let prod_reach = reachable_without(
+        &canonical,
+        &all_roots,
+        &[DepType::Dev, DepType::Optional],
+        true,
+    );
+    // `peer: true` is the fourth flag: a package no path reaches without
+    // crossing a peer edge — an importer's own synthesized peer included.
+    let declared_roots: Vec<DirectDep> = graph
+        .importers
+        .iter()
+        .flat_map(|(importer_path, deps)| {
+            deps.iter()
+                .filter(move |dep| !synthesized_peer(importer_path, dep))
+                .cloned()
+        })
+        .collect();
+    let non_peer_reach = reachable_without(&canonical, &declared_roots, &[], false);
 
     // Build a hoist/nest tree keyed by a sequence of "node_modules"
     // path segments — e.g. `["foo"]` for `node_modules/foo`,
     // `["foo", "bar"]` for `node_modules/foo/node_modules/bar`. Shared
     // with bun (which renders the same segment list as `foo/bar`).
-    let root_tree_roots = non_link_roots(graph, &roots);
+    let mut root_tree_roots = non_link_roots(graph, &roots);
     let preferred_roots = preferred_root_placements(path, &canonical);
+    // npm hoists a workspace member's dependency to the root `node_modules`
+    // when nothing conflicts and keeps it there on a later install. The
+    // preferred placements above are gated on reachability from the tree's
+    // roots, which a member-only dep never is, so one the existing file
+    // hoisted joins the roots at that version: the rewrite then keeps npm's
+    // placement instead of nesting the dep, and its subtree, under the
+    // member. A fresh write, with no file to prefer, still nests.
+    let mut root_names: BTreeSet<String> =
+        root_tree_roots.iter().map(|dep| dep.name.clone()).collect();
+    for (_, importer_roots) in graph.importers.iter().filter(|(p, _)| *p != ".") {
+        for dep in non_link_roots(graph, importer_roots) {
+            let key = super::canonical_key_from_dep_path(&dep.dep_path);
+            if preferred_roots.get(&dep.name) == Some(&key) && root_names.insert(dep.name.clone()) {
+                root_tree_roots.push(dep);
+            }
+        }
+    }
     let tree = super::build_hoist_tree(&canonical, &root_tree_roots, Some(&preferred_roots));
     // For the npm writer, re-key the tree by install_path strings.
     let mut placed: BTreeMap<String, String> = tree
@@ -426,34 +535,6 @@ pub fn write(
     // they need no reservation set; the members' do, and theirs is built
     // below once the member identities are known.
     emit_file_dep_links(graph, &roots, ".", &Default::default(), &mut packages);
-
-    // Resolve each workspace member's identity (name/version/peers).
-    // A `LocalSource::Link` package exists only when the graph was
-    // *read* from an npm lockfile (the reader synthesizes it from the
-    // `node_modules/<name>: {link:true}` pair). On a fresh resolve from
-    // package.json there is no such package, so recover the member's
-    // name/version/peers from its own `package.json` on disk — the same
-    // best-effort disk read the pnpm and bun writers use. Without this
-    // fallback every member importer + its child deps were dropped and
-    // `npm ci` rejected the lockfile with `Missing: <member> from lock
-    // file`.
-    // Pre-read every member's `package.json` once, up front, so the
-    // borrowed name/version/peer strings live as long as `packages`
-    // (the `WriteNpmPackage` arena borrows them). Only read for importers
-    // without a `LocalSource::Link` package — i.e. a fresh resolve.
-    let project_dir = path.parent().unwrap_or_else(|| Path::new("."));
-    let member_manifests: BTreeMap<&str, aube_manifest::PackageJson> = graph
-        .importers
-        .keys()
-        .filter(|p| p.as_str() != ".")
-        .filter(|p| workspace_package_for_importer(graph, p).is_none())
-        .map(|p| {
-            let m =
-                aube_manifest::PackageJson::from_path(&project_dir.join(p).join("package.json"))
-                    .unwrap_or_default();
-            (p.as_str(), m)
-        })
-        .collect();
 
     // Every name that will end up owning a root `node_modules/<name>`
     // entry, gathered before the member loop writes anything: each
@@ -528,12 +609,24 @@ pub fn write(
             (None, None) => BTreeMap::new(),
         };
 
-        let (dependencies, dev_dependencies, optional_dependencies) =
+        let (mut dependencies, dev_dependencies, optional_dependencies) =
             dep_sections_from_direct_deps(importer_roots);
+        // The member's synthesized peer is listed under `peerDependencies`
+        // only, as npm writes it.
+        dependencies.retain(|name, _| {
+            !importer_roots
+                .iter()
+                .any(|dep| dep.name == *name && synthesized_peer(importer_path, dep))
+        });
+        // npm names a member entry only when the package name differs from
+        // the directory's basename (`packages/browsers` → `@puppeteer/browsers`
+        // carries one, `packages/puppeteer` does not), measured on real
+        // lockfiles; always writing it churns every plainly named member.
+        let dir_name = importer_path.rsplit('/').next().unwrap_or(importer_path);
         packages.insert(
             importer_path.clone(),
             WriteNpmPackage {
-                name: Some(member_name),
+                name: (member_name != dir_name).then_some(member_name),
                 version: member_version,
                 dependencies,
                 dev_dependencies,
@@ -606,10 +699,21 @@ pub fn write(
         // treats that as a corrupt lockfile, and `npm install`
         // would refetch the dropped package. Matches the bun and
         // yarn writers, which filter the same way.
+        // A peer that reached `dependencies` as a graph edge — recorded by
+        // placement in the npm reader's second pass, or merged by the peer
+        // pass — is not a declared dependency: npm lists it under
+        // `peerDependencies` only, so it is emitted there and nowhere else,
+        // an optional one included. A name a package declares in both
+        // sections keeps both.
+        let placed_peer = |n: &str| -> bool {
+            pkg.peer_dependencies.contains_key(n) && !pkg.declared_dependencies.contains_key(n)
+        };
         let optional_deps: BTreeMap<&str, &str> = pkg
             .optional_dependencies
             .iter()
-            .filter(|(n, value)| canonical.contains_key(&super::child_canonical_key(n, value)))
+            .filter(|(n, value)| {
+                !placed_peer(n) && canonical.contains_key(&super::child_canonical_key(n, value))
+            })
             .map(|(n, value)| {
                 // Prefer the declared range from the package's own
                 // manifest (what npm itself writes) over the resolved
@@ -629,6 +733,7 @@ pub fn write(
             .iter()
             .filter(|(n, value)| {
                 !pkg.optional_dependencies.contains_key(*n)
+                    && !placed_peer(n)
                     && canonical.contains_key(&super::child_canonical_key(n, value))
             })
             .map(|(n, value)| {
@@ -664,6 +769,7 @@ pub fn write(
         // optional chain). The all-paths-dev-and-optional case
         // collapses into the same flag.
         let is_dev_opt = is_reachable && !prod_reach.contains(canonical_key);
+        let peer = is_reachable && !non_peer_reach.contains(canonical_key);
         let dev_optional = (is_dev && is_opt) || (is_dev_opt && !is_dev && !is_opt);
         let dev = is_dev && !is_opt;
         let optional = is_opt && !is_dev;
@@ -740,6 +846,7 @@ pub fn write(
                     .map(|url| WriteNpmFunding { url }),
                 dev,
                 optional,
+                peer,
                 dev_optional,
                 bundle_dependencies: pkg
                     .bundled_dependencies
@@ -1034,11 +1141,15 @@ fn dep_sections_from_direct_deps(deps: &[DirectDep]) -> DepSections<'_> {
 /// type; below the root the only typed edges are
 /// `optionalDependencies` (a dependency's `devDependencies` are
 /// never installed), so the `Dev` exclusion filters seeds only,
-/// while the `Optional` exclusion also filters child edges.
+/// while the `Optional` exclusion also filters child edges. A peer edge
+/// — a child the package declares only as a peer, recorded by placement
+/// or merged by the peer pass — is crossed unless `cross_peer_edges` is
+/// off, which is how npm's `peer` flag is derived.
 fn reachable_without(
     canonical: &BTreeMap<String, &LockedPackage>,
     roots: &[DirectDep],
     excluded: &[DepType],
+    cross_peer_edges: bool,
 ) -> BTreeSet<String> {
     let mut out: BTreeSet<String> = BTreeSet::new();
     let mut queue: VecDeque<String> = VecDeque::new();
@@ -1058,6 +1169,12 @@ fn reachable_without(
         for (child_name, child_value) in &pkg.dependencies {
             if excluded.contains(&DepType::Optional)
                 && pkg.optional_dependencies.contains_key(child_name)
+            {
+                continue;
+            }
+            if !cross_peer_edges
+                && pkg.peer_dependencies.contains_key(child_name)
+                && !pkg.declared_dependencies.contains_key(child_name)
             {
                 continue;
             }

--- a/vendor/aube/crates/aube-lockfile/tests/fixtures/npm-native-peer.json
+++ b/vendor/aube/crates/aube-lockfile/tests/fixtures/npm-native-peer.json
@@ -1,0 +1,112 @@
+{
+  "name": "aube-lockfile-peer-flags",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aube-lockfile-peer-flags",
+      "version": "1.0.0",
+      "dependencies": {
+        "react-dom": "18.3.1"
+      },
+      "devDependencies": {
+        "react-redux": "9.2.0"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    }
+  }
+}

--- a/vendor/aube/crates/aube-lockfile/tests/fixtures/npm-native-root-peer.json
+++ b/vendor/aube/crates/aube-lockfile/tests/fixtures/npm-native-root-peer.json
@@ -1,0 +1,85 @@
+{
+  "name": "root-peer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "root-peer",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "peerDependencies": {
+        "react": "18.3.1"
+      }
+    },
+    "node_modules/a": {
+      "resolved": "packages/a",
+      "link": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "packages/a": {
+      "version": "1.0.0",
+      "peerDependencies": {
+        "react-dom": "18.3.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
npm records the copy of a peer each dependent sees (`peer: true`, hoisted or nested) and ties it to no dependency edge. The reader left peers to the peer pass, which (1) let a peer-only package reached only through a transitive package's peer edge be pruned as unreachable — `react-dom` under react-element-to-jsx-string in ava and dotenv, `search-insights` in promptfoo, `@types/node` in axios — and (2) with no satisfying ancestor, picked the newest version in the graph or an out-of-range ancestor copy (eslint-plugin-react got eslint 10 with npm's nested eslint 9 in the lockfile).

The reader now resolves each peer by placement and records it as a dependency edge; the writer keeps such an edge out of `dependencies`. Found by the corpus in #922.

A third shape, also from the corpus: a `link` entry inside `node_modules` whose target is a registry package above it (puppeteer's nested browserslist) was read as a local package with no integrity, so the package was never fetched. Such a link now resolves to its target.

The root's and a workspace member's own declared peers, which the reader enters on their importers as direct deps, keep npm's `peer: true` on write; a member-only dep the existing lockfile hoisted stays at the root on a rewrite, and a member entry names itself only when the name differs from its directory. A second native npm fixture covers both importers.