### PR TITLE
pm: run npm ci and npm install on nub's engine behind `nub pm shim --route-installs`

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -3399,6 +3399,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 node_linker,
                 registry,
                 dir,
+                allow_all_builds: false,
                 filter: crate::pm_engine::WorkspaceFilterFlags {
                     filter,
                     filter_prod,
@@ -3434,6 +3435,7 @@ fn dispatch_subcommand(rest: Vec<String>) -> Result<i32> {
                 no_optional,
                 registry,
                 dir,
+                allow_all_builds: false,
                 filter: crate::pm_engine::WorkspaceFilterFlags {
                     filter,
                     filter_prod,
@@ -9876,7 +9878,9 @@ fn run_pm(args: &[String]) -> Result<i32> {
              \x20 pin [<version>]    lock this project to an exact nub version (default: the running nub)\n\
              \x20 update             re-resolve within the pinned range and bump the pin (alias: up)\n\
              \x20 cache [clear]      list cached package managers (or clear the cache)\n\
-             \x20 shim               link npm/pnpm/yarn shims onto PATH (re-run after `nub upgrade`)\n\
+             \x20 shim               link npm/pnpm/yarn shims onto PATH (re-run after `nub upgrade`);\n\
+             \x20                    --route-installs runs `npm ci` / `npm install` on nub's engine\n\
+             \x20                    (--no-route-installs turns that back off)\n\
              \x20 unshim             remove the shims and their PATH block"
         );
         return Ok(0);
@@ -10091,7 +10095,7 @@ fn run_pm(args: &[String]) -> Result<i32> {
         // `nub node pin <version>`.
         "pin" => run_pm_pin(args.get(1).map(String::as_str), &cwd),
         // Install / remove the PM shims (spec: `package-manager-shims` (no such document)).
-        "shim" => run_pm_shim_install(),
+        "shim" => run_pm_shim_install(&args[1..]),
         "unshim" => run_pm_unshim(),
         // `switch` (the old cross-PM, declaration-only verb) was replaced by
         // `use` (2026-06-10, identity-policy ratification) — name the successor
@@ -10700,8 +10704,22 @@ fn list_pm_cache(pm_cache: &Path) -> Vec<String> {
 /// in `~/.nub/shims`, write the marked PATH block into the shell profile
 /// (install.sh's mechanism), and verify reachability. Idempotent — re-running
 /// re-links, which is also how shims are refreshed after `nub upgrade`.
-fn run_pm_shim_install() -> Result<i32> {
+fn run_pm_shim_install(args: &[String]) -> Result<i32> {
     use nub_core::pm::shim::{self, ProfileOutcome, ShimAction};
+
+    // `--route-installs` / `--no-route-installs` set or clear the marker; a
+    // re-run without either leaves the current choice alone, so re-linking
+    // after `nub upgrade` never silently switches routing off.
+    let mut route_installs: Option<bool> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--route-installs" => route_installs = Some(true),
+            "--no-route-installs" => route_installs = Some(false),
+            other => bail!(
+                "nub pm shim: unexpected argument {other:?} (accepted: --route-installs, --no-route-installs)"
+            ),
+        }
+    }
 
     // Canonicalized, so a symlinked `nub` on PATH links the real bytes (the
     // same posture as every other `current_nub_binary` call site).
@@ -10721,6 +10739,9 @@ fn run_pm_shim_install() -> Result<i32> {
     }
 
     let report = shim::install_shims(&nub_binary)?;
+    if let Some(on) = route_installs {
+        shim::set_route_installs(&dir, on)?;
+    }
 
     let count = |action: ShimAction| report.iter().filter(|s| s.action == action).count();
     let (created, relinked, current) = (
@@ -10749,6 +10770,11 @@ fn run_pm_shim_install() -> Result<i32> {
         dir.display(),
         parts.join(", ")
     );
+    if shim::route_installs_enabled(&dir) {
+        println!(
+            "  npm ci and npm install run on nub's engine (--no-route-installs turns this off)"
+        );
+    }
     if report.iter().any(|s| s.copied) {
         println!(
             "  note: {} is on a different filesystem than the nub binary — \
@@ -11065,6 +11091,15 @@ enum ShimPlan {
     },
     /// The strict agreement check refused: print `message` on stderr, exit 1.
     Refuse { message: String },
+    /// `npm ci` / `npm install` under `nub pm shim --route-installs`: run the
+    /// install on nub's engine, in this process (`nub ci` / `nub install
+    /// --no-frozen-lockfile` with npm's flags translated, every lifecycle
+    /// script allowed as npm allows them). `ignore_scripts` is npm's
+    /// effective value: the command line, else its config.
+    EngineInstall {
+        route: nub_core::pm::shim::NpmEngineInstall,
+        ignore_scripts: bool,
+    },
 }
 
 /// The corepack-style "which PM am I running" notice for the shim-dispatch
@@ -11101,6 +11136,54 @@ fn run_pm_shim(invoked: nub_core::pm::shim::ShimName, args: &[String]) -> Result
             Ok(1)
         }
         ShimPlan::Exec { program, args, env } => exec_program(&program, &args, &env),
+        ShimPlan::EngineInstall {
+            route,
+            ignore_scripts,
+        } => run_shim_engine_install(route, ignore_scripts),
+    }
+}
+
+/// The routed install: the corepack-style notice names what runs in place of
+/// npm, then the engine runs in-process exactly as `nub ci` / `nub install`
+/// would from this cwd.
+fn run_shim_engine_install(
+    route: nub_core::pm::shim::NpmEngineInstall,
+    ignore_scripts: bool,
+) -> Result<i32> {
+    use nub_core::pm::shim::NpmInstallVerb;
+    // npm hands every lifecycle script `NODE_ENV=production` exactly when
+    // dev dependencies are effectively omitted (`buildOmitList` in npm's
+    // config definitions). Per child through the engine's overlay, never the
+    // process environment (A19).
+    if route.prod {
+        crate::pm_engine::set_lifecycle_env(vec![("NODE_ENV".into(), "production".into())]);
+    }
+    let (from, to) = match route.verb {
+        NpmInstallVerb::Ci => ("npm ci", "nub ci"),
+        NpmInstallVerb::Install => ("npm install", "nub install"),
+    };
+    let line = format!("{from} → {to} (via nub shim)");
+    if crate::pm_engine::scope_warning_uses_dim() {
+        eprintln!("\x1b[2m{line}\x1b[0m");
+    } else {
+        eprintln!("{line}");
+    }
+    match route.verb {
+        NpmInstallVerb::Ci => crate::pm_engine::run_ci(crate::pm_engine::CiFlags {
+            prod: route.prod,
+            ignore_scripts,
+            no_optional: route.no_optional,
+            allow_all_builds: true,
+            ..Default::default()
+        }),
+        NpmInstallVerb::Install => crate::pm_engine::run_install(crate::pm_engine::InstallFlags {
+            no_frozen_lockfile: true,
+            prod: route.prod,
+            ignore_scripts,
+            no_optional: route.no_optional,
+            allow_all_builds: true,
+            ..Default::default()
+        }),
     }
 }
 
@@ -11113,9 +11196,22 @@ fn shim_plan(
     args: &[String],
     cwd: &Path,
 ) -> Result<ShimPlan> {
+    let route_installs =
+        nub_core::pm::shim::route_installs_enabled(&nub_core::pm::shim::shim_dir()?);
+    shim_plan_with(invoked, args, cwd, route_installs)
+}
+
+/// [`shim_plan`] with the `--route-installs` opt-in passed in, so the routing
+/// branch is unit-testable without a real shim dir.
+fn shim_plan_with(
+    invoked: nub_core::pm::shim::ShimName,
+    args: &[String],
+    cwd: &Path,
+    route_installs: bool,
+) -> Result<ShimPlan> {
     use nub_core::pm::Pm;
     use nub_core::pm::resolve::{self, PmTarget};
-    use nub_core::pm::shim::{self, Nesting, ShimDecision};
+    use nub_core::pm::shim::{self, Nesting, ShimDecision, ShimName};
 
     let target = resolve::resolve_target(cwd);
     let pin_state = shim_pin_state(cwd, target.as_ref());
@@ -11134,13 +11230,46 @@ fn shim_plan(
     // cross-PM project-pin refusal does not apply — `decide` lets it fall through.
     let global = shim::is_global_invocation(invoked, args);
 
-    match shim::decide(
+    let decision = shim::decide(
         invoked,
         &pin_state,
         args.first().map(String::as_str),
         nesting,
         global,
-    ) {
+    );
+
+    // `nub pm shim --route-installs`: a top-level `npm ci` / bare `npm
+    // install` in a project whose lockfile is npm's runs on nub's engine. Only
+    // where npm itself would have run (the matrix did not refuse), only at top
+    // level (a lifecycle script's nested `npm install` keeps the real npm —
+    // the engine is already running one layer up), never for a global op, and
+    // only for an argv the engine honors verbatim ([`shim::npm_install_route`]).
+    // Without an npm lockfile there is nothing frozen to install from, so the
+    // real npm keeps that case too.
+    if route_installs
+        && invoked == ShimName::Npm
+        && nesting == Nesting::TopLevel
+        && !global
+        && matches!(
+            decision,
+            ShimDecision::RunPinned { pm: Pm::Npm, .. } | ShimDecision::FallThrough { .. }
+        )
+        && let Some(route) = shim::npm_install_route(args, node_env_is_production())
+    {
+        let root = shim_lockfile_root(cwd);
+        if root.join("package-lock.json").is_file() || root.join("npm-shrinkwrap.json").is_file() {
+            // The command line outranks npm's config, as it does for npm.
+            let ignore_scripts = route
+                .ignore_scripts
+                .unwrap_or_else(|| shim::npm_ignore_scripts_configured(&root));
+            return Ok(ShimPlan::EngineInstall {
+                route,
+                ignore_scripts,
+            });
+        }
+    }
+
+    match decision {
         ShimDecision::Refuse {
             pinned_pm,
             provenance,
@@ -11236,6 +11365,11 @@ fn shim_plan(
             exec_under_project_node(cwd, bin, args)
         }
     }
+}
+
+/// npm reads `NODE_ENV=production` as `--omit=dev`; the routed install does too.
+fn node_env_is_production() -> bool {
+    env::var("NODE_ENV").is_ok_and(|v| v == "production")
 }
 
 /// Derive the decision core's [`PinState`] from the resolved [`PmTarget`].
@@ -14310,6 +14444,91 @@ mod tests {
             ),
             other => panic!("pnpm in a yarnPath project must refuse, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn shim_plan_routes_npm_installs_only_when_opted_in_with_an_npm_lockfile() {
+        use nub_core::pm::shim::{NpmInstallVerb, ShimName};
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"p","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        let ci = vec!["ci".to_string()];
+        // No npm lockfile: nothing frozen to install from, so npm keeps it.
+        assert!(
+            !matches!(
+                shim_plan_with(ShimName::Npm, &ci, &dir, true).unwrap(),
+                ShimPlan::EngineInstall { .. }
+            ),
+            "without package-lock.json the real npm runs"
+        );
+        std::fs::write(
+            dir.join("package-lock.json"),
+            r#"{"lockfileVersion":3,"packages":{}}"#,
+        )
+        .unwrap();
+        match shim_plan_with(ShimName::Npm, &ci, &dir, true).unwrap() {
+            ShimPlan::EngineInstall {
+                route,
+                ignore_scripts,
+            } => {
+                assert_eq!(route.verb, NpmInstallVerb::Ci);
+                assert!(!ignore_scripts, "no config and no flag: scripts run");
+            }
+            other => {
+                panic!("an opted-in npm ci with an npm lockfile runs on the engine, got {other:?}")
+            }
+        }
+        assert!(
+            !matches!(
+                shim_plan_with(ShimName::Npm, &ci, &dir, false).unwrap(),
+                ShimPlan::EngineInstall { .. }
+            ),
+            "without the opt-in the real npm runs"
+        );
+        // npm's config decides when the command line is silent, and the
+        // command line wins when it is not.
+        std::fs::write(dir.join(".npmrc"), "ignore-scripts=true\n").unwrap();
+        assert!(matches!(
+            shim_plan_with(ShimName::Npm, &ci, &dir, true).unwrap(),
+            ShimPlan::EngineInstall {
+                ignore_scripts: true,
+                ..
+            }
+        ));
+        let explicit = vec!["ci".to_string(), "--ignore-scripts=false".to_string()];
+        assert!(matches!(
+            shim_plan_with(ShimName::Npm, &explicit, &dir, true).unwrap(),
+            ShimPlan::EngineInstall {
+                ignore_scripts: false,
+                ..
+            }
+        ));
+        std::fs::remove_file(dir.join(".npmrc")).unwrap();
+        // A pinned npm still routes the install; the pin governs npm's other verbs.
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"p","version":"1.0.0","packageManager":"npm@11.0.0"}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            shim_plan_with(ShimName::Npm, &ci, &dir, true).unwrap(),
+            ShimPlan::EngineInstall { .. }
+        ));
+        // A project pinned to another PM refuses as before — routing never
+        // overrides the matrix.
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"p","version":"1.0.0","packageManager":"pnpm@9.0.0"}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            shim_plan_with(ShimName::Npm, &ci, &dir, true).unwrap(),
+            ShimPlan::Refuse { .. }
+        ));
     }
 
     #[test]

--- a/crates/nub-cli/src/pm_engine/install_family.rs
+++ b/crates/nub-cli/src/pm_engine/install_family.rs
@@ -1221,6 +1221,12 @@ pub struct InstallFlags {
     pub node_linker: Option<String>,
     pub registry: Option<String>,
     pub dir: Option<std::path::PathBuf>,
+    /// Run every lifecycle script, as npm does. Not a CLI flag: set only by the
+    /// `npm` shim's install routing, where the user typed `npm ci` and npm's
+    /// contract is that scripts run. Composes with the default-trust floor
+    /// like `dangerouslyAllowAllBuilds` — an explicit `allowBuilds: false`
+    /// still denies.
+    pub allow_all_builds: bool,
     /// Workspace selectors (`--filter`/`-r`/…), routed through the same
     /// `EffectiveFilter` path the registry verbs (`add`/`remove`/`update`) use.
     pub filter: WorkspaceFilterFlags,
@@ -1240,6 +1246,8 @@ pub struct CiFlags {
     pub no_optional: bool,
     pub registry: Option<String>,
     pub dir: Option<std::path::PathBuf>,
+    /// See [`InstallFlags::allow_all_builds`].
+    pub allow_all_builds: bool,
     /// Workspace selectors (`--filter`/`-r`/…) — same path as `install`.
     pub filter: WorkspaceFilterFlags,
     /// Output-verbosity flags (`--reporter`/`--silent`/`--loglevel`).
@@ -1329,6 +1337,7 @@ pub fn run_install(flags: InstallFlags) -> Result<i32> {
     args.force = flags.force;
     args.node_linker = flags.node_linker.clone();
     args.network.registry = flags.registry.clone();
+    args.dangerously_allow_all_builds = flags.allow_all_builds;
     // Config-requested frozen seeds the strict mode unless the CLI explicitly
     // opted out (`--no-frozen-lockfile`).
     args.lockfile.frozen_lockfile =
@@ -1613,6 +1622,7 @@ pub fn run_ci(flags: CiFlags) -> Result<i32> {
             dep.no_optional || flags.no_optional,
         ),
         ignore_scripts: flags.ignore_scripts,
+        dangerously_allow_all_builds: flags.allow_all_builds,
         build_policy_override: config
             .scripts_disabled
             .then(|| std::sync::Arc::new(aube_scripts::BuildPolicy::deny_all())),

--- a/crates/nub-cli/src/pm_engine/mod.rs
+++ b/crates/nub-cli/src/pm_engine/mod.rs
@@ -99,6 +99,24 @@ use aube_lockfile::LockfileKind;
 #[cfg(test)]
 pub(crate) static ENGINE_GLOBAL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Environment a frontend adds to every lifecycle-script spawn of this
+/// process's one install, on top of the runtime-augmentation overlay
+/// [`apply_lifecycle_augmentation`] builds. Set once, before the engine
+/// session opens; the npm-routing shim fills it with npm's
+/// `NODE_ENV=production` under an effective `omit=dev`. Per child, never the
+/// process environment (A19).
+static LIFECYCLE_ENV_EXTRA: std::sync::OnceLock<Vec<(std::ffi::OsString, std::ffi::OsString)>> =
+    std::sync::OnceLock::new();
+
+pub fn set_lifecycle_env(pairs: Vec<(String, String)>) {
+    let _ = LIFECYCLE_ENV_EXTRA.set(
+        pairs
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect(),
+    );
+}
+
 /// The four engine verb families. One module per family; each family module
 /// owns the wiring (args parsing, options construction, output routing) for
 /// its verbs.
@@ -890,6 +908,10 @@ fn engine_session_inner(
     // compiled against ambient Node instead of the project's. Default-empty
     // overlay when augmentation can't engage ⇒ behavior preserved.
     apply_lifecycle_augmentation(&cwd)?;
+    if let Some(extra) = LIFECYCLE_ENV_EXTRA.get() {
+        let extra = extra.clone();
+        aube_util::update_engine_context(move |c| c.env_overlay.extend(extra));
+    }
     Ok(EngineSession {
         detected,
         runtime: build_runtime()?,

--- a/crates/nub-cli/tests/pm_shim.rs
+++ b/crates/nub-cli/tests/pm_shim.rs
@@ -615,6 +615,309 @@ fn pm_shim_and_unshim_round_trip_against_a_temp_home() {
     assert_eq!(code4, 0, "a second unshim is a clean no-op");
 }
 
+/// A project whose lockfile is npm's, with one `file:` dependency and no
+/// registry package, so the engine installs it with the registry dead.
+fn npm_link_only_project(work: &Path) -> PathBuf {
+    let proj = work.join("proj");
+    std::fs::create_dir_all(proj.join("local-dep")).unwrap();
+    // A root postinstall that records whether it ran, and with which
+    // NODE_ENV — the probe for npm's script semantics under routing.
+    std::fs::write(
+        proj.join("package.json"),
+        r#"{ "name": "proj", "version": "1.0.0", "dependencies": { "local-dep": "file:local-dep" },
+  "optionalDependencies": { "opt-dep": "file:opt-dep" },
+  "scripts": { "postinstall": "node -e \"require('fs').writeFileSync('postinstall.txt', String(process.env.NODE_ENV))\"" } }"#,
+    )
+    .unwrap();
+    // The link target's `prepare`: npm runs it in the target directory
+    // (its link build pass), so its artifact must appear there — and the
+    // bin it generates must resolve through `.bin` afterwards. The optional
+    // link's `prepare` fails, which npm survives.
+    std::fs::write(
+        proj.join("local-dep/package.json"),
+        r#"{ "name": "local-dep", "version": "1.0.0", "bin": { "local-dep-bin": "gen.js" },
+  "scripts": { "prepare": "node -e \"require('fs').writeFileSync('prepared.txt', '1'); require('fs').writeFileSync('gen.js', '#!/usr/bin/env node\\nconsole.log(42)')\"" } }"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(proj.join("opt-dep")).unwrap();
+    std::fs::write(
+        proj.join("opt-dep/package.json"),
+        r#"{ "name": "opt-dep", "version": "1.0.0", "bin": { "opt-dep-bin": "bin.js" },
+  "scripts": { "prepare": "node -e process.exit(1)" } }"#,
+    )
+    .unwrap();
+    std::fs::write(
+        proj.join("opt-dep/bin.js"),
+        "#!/usr/bin/env node\nconsole.log(7)\n",
+    )
+    .unwrap();
+    std::fs::write(
+        proj.join("package-lock.json"),
+        r#"{
+  "name": "proj",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": { "name": "proj", "version": "1.0.0", "dependencies": { "local-dep": "file:local-dep" },
+      "optionalDependencies": { "opt-dep": "file:opt-dep" } },
+    "local-dep": { "version": "1.0.0", "bin": { "local-dep-bin": "gen.js" } },
+    "node_modules/local-dep": { "resolved": "local-dep", "link": true },
+    "opt-dep": { "version": "1.0.0", "bin": { "opt-dep-bin": "bin.js" } },
+    "node_modules/opt-dep": { "resolved": "opt-dep", "link": true, "optional": true }
+  }
+}
+"#,
+    )
+    .unwrap();
+    proj
+}
+
+/// `nub pm shim --route-installs` into a temp HOME, returning the shim dir:
+/// the marker lands beside the six links, and the `npm` link reads it.
+fn shims_with_routing(home: &Path, route: bool) -> PathBuf {
+    let env: Vec<(&str, &str)> = vec![("HOME", home.to_str().unwrap()), ("SHELL", "/bin/zsh")];
+    let args: &[&str] = if route {
+        &["pm", "shim", "--route-installs"]
+    } else {
+        &["pm", "shim"]
+    };
+    let (stdout, stderr, code) = run(&nub_binary(), args, home, &env);
+    assert_eq!(code, 0, "nub pm shim must succeed; stderr:\n{stderr}");
+    assert_eq!(
+        stdout.contains("run on nub's engine"),
+        route,
+        "the report names the routing exactly when it is on, got:\n{stdout}"
+    );
+    home.join(".local/share/nub/shims")
+}
+
+/// Under `nub pm shim --route-installs`, a top-level `npm ci` in an
+/// npm-lockfile project runs on nub's engine — the notice names the swap and
+/// the tree carries the engine's marker — while every other npm invocation,
+/// and an install argv the engine cannot honor verbatim, still reaches the
+/// real npm with its argv untouched.
+#[test]
+fn routed_npm_ci_runs_on_the_engine_and_everything_else_reaches_the_real_npm() {
+    let work = tmp("route");
+    let home = work.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let shims = shims_with_routing(&home, true);
+    let proj = npm_link_only_project(&work);
+    let sys = work.join("sys");
+    std::fs::create_dir_all(&sys).unwrap();
+    let fake = fake_pm(&sys, "npm");
+
+    // A dead registry beside a fresh store: the link-only lockfile needs no
+    // fetch, so a routed install that reaches the network fails fast here.
+    let cache = work.join("cache");
+    std::fs::create_dir_all(cache.join("nub")).unwrap();
+    std::fs::write(cache.join("nub/.npmrc"), "registry=http://127.0.0.1:1/\n").unwrap();
+    let path = format!(
+        "{}:{}:{}",
+        shims.display(),
+        sys.display(),
+        std::env::var("PATH").unwrap()
+    );
+    let env: Vec<(&str, &str)> = vec![
+        ("HOME", home.to_str().unwrap()),
+        ("PATH", path.as_str()),
+        ("XDG_CACHE_HOME", cache.to_str().unwrap()),
+    ];
+    let npm = shims.join("npm");
+
+    let (stdout, stderr, code) = run(&npm, &["ci"], &proj, &env);
+    assert_eq!(code, 0, "the routed npm ci must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("npm ci → nub ci (via nub shim)"),
+        "the notice names what ran in npm's place, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("did not run"),
+        "a linked directory is not a store build, so allow-all has nothing to report as unattempted; got:\n{stderr}"
+    );
+    assert!(
+        proj.join("node_modules/.nub-engine").is_file(),
+        "the engine installed the tree (its marker is there); stdout:\n{stdout}"
+    );
+    assert!(
+        proj.join("node_modules/local-dep")
+            .symlink_metadata()
+            .is_ok(),
+        "the file: dependency is linked"
+    );
+    assert!(
+        !stdout.contains("FAKE:"),
+        "the real npm never ran, got:\n{stdout}"
+    );
+    let postinstall = proj.join("postinstall.txt");
+    assert_eq!(
+        std::fs::read_to_string(&postinstall).unwrap(),
+        "undefined",
+        "the root postinstall ran, with no NODE_ENV forced on it"
+    );
+    let prepared = proj.join("local-dep/prepared.txt");
+    assert!(
+        prepared.is_file(),
+        "the file: link's prepare ran in the link target, as npm's link build pass does"
+    );
+    let (bin_out, bin_err, bin_code) = run(
+        &proj.join("node_modules/.bin/local-dep-bin"),
+        &[],
+        &proj,
+        &env,
+    );
+    assert_eq!(
+        (bin_out.trim(), bin_code),
+        ("42", 0),
+        "the bin the link's prepare generated resolves through .bin; stderr:\n{bin_err}"
+    );
+    assert!(
+        stderr.contains("opt-dep@1.0.0 is an optional dependency and failed to build"),
+        "the optional link's failing prepare is a warning, not a failure, got:\n{stderr}"
+    );
+    let opt_link = proj.join("node_modules/opt-dep");
+    assert!(
+        opt_link.symlink_metadata().is_err()
+            && !proj.join("node_modules/.bin/opt-dep-bin").exists(),
+        "a failed optional link leaves the tree with its bin, as npm trashes the node"
+    );
+
+    // npm's dependency axis: an effective omit=dev hands lifecycle scripts
+    // NODE_ENV=production; --include=dev takes both back.
+    std::fs::remove_file(&postinstall).unwrap();
+    let (_, stderr, code) = run(&npm, &["ci", "--omit=dev"], &proj, &env);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert_eq!(std::fs::read_to_string(&postinstall).unwrap(), "production");
+    std::fs::remove_file(&postinstall).unwrap();
+    let (_, stderr, code) = run(&npm, &["ci", "--omit=dev", "--include=dev"], &proj, &env);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert_eq!(std::fs::read_to_string(&postinstall).unwrap(), "undefined");
+
+    // npm's ignore-scripts config is honored — the project .npmrc, and the
+    // environment above it — and the command line outranks both.
+    std::fs::remove_file(&postinstall).unwrap();
+    std::fs::write(proj.join(".npmrc"), "ignore-scripts=true\n").unwrap();
+    std::fs::remove_file(&prepared).unwrap();
+    let (_, stderr, code) = run(&npm, &["ci"], &proj, &env);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert!(
+        !postinstall.exists() && !prepared.exists(),
+        ".npmrc ignore-scripts=true suppresses the postinstall and the link's prepare"
+    );
+    assert!(
+        opt_link.symlink_metadata().is_ok(),
+        "with scripts ignored nothing failed, so the optional link stays: the removal is tied to the failure"
+    );
+    let (_, stderr, code) = run(&npm, &["ci", "--ignore-scripts=false"], &proj, &env);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert!(
+        postinstall.exists(),
+        "--ignore-scripts=false on the command line wins over .npmrc"
+    );
+    std::fs::remove_file(proj.join(".npmrc")).unwrap();
+    std::fs::remove_file(&postinstall).unwrap();
+    let with_env: Vec<(&str, &str)> = env
+        .iter()
+        .copied()
+        .chain([("NPM_CONFIG_IGNORE_SCRIPTS", "true")])
+        .collect();
+    let (_, stderr, code) = run(&npm, &["ci"], &proj, &with_env);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert!(
+        !postinstall.exists(),
+        "npm_config_ignore_scripts in the environment suppresses the postinstall"
+    );
+
+    // A bare `npm install` routes too, without the frozen gate.
+    std::fs::remove_dir_all(proj.join("node_modules")).unwrap();
+    let (_, stderr, code) = run(&npm, &["install", "--no-audit"], &proj, &env);
+    assert_eq!(
+        code, 0,
+        "the routed npm install must succeed; stderr:\n{stderr}"
+    );
+    assert!(stderr.contains("npm install → nub install (via nub shim)"));
+    assert!(proj.join("node_modules/.nub-engine").is_file());
+
+    // Everything else is npm's: no verb, and an install flag outside the
+    // translated set, both exec the real npm with the argv verbatim.
+    for argv in [
+        &["--version"][..],
+        &["ci", "--legacy-peer-deps"][..],
+        &["run", "build"][..],
+    ] {
+        let (stdout, stderr, code) = run(&npm, argv, &proj, &env);
+        assert_eq!(code, 0, "{argv:?}: stderr:\n{stderr}");
+        assert_eq!(
+            stdout,
+            format!("FAKE:{}:{}\n", fake.display(), argv.join(" ")),
+            "{argv:?} must reach the real npm untouched"
+        );
+    }
+
+    // A nested call — a lifecycle script's `npm ci` under a running
+    // install — keeps the real npm: the engine is already running above it.
+    let nested: Vec<(&str, &str)> = env
+        .iter()
+        .copied()
+        .chain([
+            ("npm_config_user_agent", "npm/11.0.0 node/v24.0.0"),
+            ("npm_execpath", "/x/npm-cli.js"),
+        ])
+        .collect();
+    let (stdout, _, _) = run(&npm, &["ci"], &proj, &nested);
+    assert!(
+        stdout.starts_with("FAKE:"),
+        "a nested npm ci reaches the real npm, got:\n{stdout}"
+    );
+}
+
+/// Without the opt-in the same `npm ci` reaches the real npm, and
+/// `--no-route-installs` takes an earlier opt-in back.
+#[test]
+fn npm_ci_reaches_the_real_npm_unless_routing_is_opted_in() {
+    let work = tmp("noroute");
+    let home = work.join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    let shims = shims_with_routing(&home, false);
+    let proj = npm_link_only_project(&work);
+    let sys = work.join("sys");
+    std::fs::create_dir_all(&sys).unwrap();
+    let fake = fake_pm(&sys, "npm");
+    let path = format!("{}:{}", shims.display(), sys.display());
+    let env: Vec<(&str, &str)> = vec![("HOME", home.to_str().unwrap()), ("PATH", path.as_str())];
+    let npm = shims.join("npm");
+
+    let (stdout, _, _) = run(&npm, &["ci"], &proj, &env);
+    assert_eq!(stdout, format!("FAKE:{}:ci\n", fake.display()));
+
+    let home_env: Vec<(&str, &str)> = vec![("HOME", home.to_str().unwrap()), ("SHELL", "/bin/zsh")];
+    let (_, _, code) = run(
+        &nub_binary(),
+        &["pm", "shim", "--route-installs"],
+        &home,
+        &home_env,
+    );
+    assert_eq!(code, 0);
+    assert!(
+        shims.join(".route-installs").is_file(),
+        "the marker lands in the shim dir"
+    );
+    let (_, _, code) = run(
+        &nub_binary(),
+        &["pm", "shim", "--no-route-installs"],
+        &home,
+        &home_env,
+    );
+    assert_eq!(code, 0);
+    assert!(
+        !shims.join(".route-installs").exists(),
+        "--no-route-installs removes it"
+    );
+    let (stdout, _, _) = run(&npm, &["ci"], &proj, &env);
+    assert_eq!(stdout, format!("FAKE:{}:ci\n", fake.display()));
+}
+
 /// Real-network e2e: a shim-invoked bare `pnpm` in a pnpm-pinned project
 /// provisions the pinned version into a fresh store and runs it under the
 /// project's Node.

--- a/crates/nub-core/src/pm/shim.rs
+++ b/crates/nub-core/src/pm/shim.rs
@@ -101,6 +101,191 @@ impl ShimName {
 /// (`npm --yes create x`) is not recognized — strictness errs toward refusing.
 const TRANSPARENT_VERBS: [&str; 4] = ["init", "create", "dlx", "exec"];
 
+/// The opt-in marker `nub pm shim --route-installs` leaves in the shim dir.
+/// While it is present, the `npm` shim runs the install verbs on nub's
+/// engine ([`npm_install_route`]); every other invocation keeps the ratified
+/// matrix above. A file rather than config so the opt-in lives and dies with
+/// the shims: `nub pm unshim` removes the dir and the routing with it, and a
+/// project checkout carries nothing.
+pub const ROUTE_INSTALLS_MARKER: &str = ".route-installs";
+
+/// Whether the shim dir carries the [`ROUTE_INSTALLS_MARKER`].
+pub fn route_installs_enabled(shim_dir: &Path) -> bool {
+    shim_dir.join(ROUTE_INSTALLS_MARKER).is_file()
+}
+
+/// Write or remove the [`ROUTE_INSTALLS_MARKER`]. Idempotent either way.
+pub fn set_route_installs(shim_dir: &Path, on: bool) -> Result<()> {
+    let marker = shim_dir.join(ROUTE_INSTALLS_MARKER);
+    if on {
+        std::fs::create_dir_all(shim_dir)
+            .with_context(|| format!("creating shim dir {}", shim_dir.display()))?;
+        std::fs::write(&marker, "").with_context(|| format!("writing {}", marker.display()))?;
+    } else if marker.is_file() {
+        std::fs::remove_file(&marker).with_context(|| format!("removing {}", marker.display()))?;
+    }
+    Ok(())
+}
+
+/// Which npm install verb the shim is routing: `ci` (frozen, node_modules
+/// removed first — `nub ci`) or a bare `install` (the lockfile is updated on
+/// drift — `nub install --no-frozen-lockfile`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NpmInstallVerb {
+    Ci,
+    Install,
+}
+
+/// An `npm ci` / `npm install` the shim runs on nub's engine, with npm's
+/// flags translated to the engine's knobs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NpmEngineInstall {
+    pub verb: NpmInstallVerb,
+    /// `--ignore-scripts[=bool]` as given on the command line; `None` when
+    /// absent, so the caller can fall back to npm's config
+    /// ([`npm_ignore_scripts_configured`]) — the command line outranks it.
+    pub ignore_scripts: Option<bool>,
+    /// Dev dependencies effectively omitted: `--omit=dev`, `--production`,
+    /// `--only=prod`, or `NODE_ENV=production`, unless `--include=dev` or
+    /// `--production=false` takes them back. npm also hands lifecycle
+    /// scripts `NODE_ENV=production` exactly then.
+    pub prod: bool,
+    /// Optional dependencies effectively omitted: `--omit=optional`,
+    /// `--no-optional`, `--optional=false`, unless `--include=optional`.
+    pub no_optional: bool,
+}
+
+/// npm's boolean spellings: a bare flag is `true`, `=true`/`=1` and
+/// `=false`/`=0` are explicit; anything else is not a boolean npm accepts
+/// here, and the caller falls through.
+fn npm_bool(value: Option<&str>) -> Option<bool> {
+    match value {
+        None | Some("true") | Some("1") => Some(true),
+        Some("false") | Some("0") => Some(false),
+        _ => None,
+    }
+}
+
+/// Classify an `npm` argv for install routing. Pure over the argv, like
+/// [`decide`]. `Some` only for the install verbs with no positional and no
+/// flag outside the translated set below; anything else — `npm install
+/// react`, `--legacy-peer-deps`, `--workspace`, `--prefix`, an unknown flag
+/// or an unknown value — is `None`, and the caller hands the argv to the real
+/// npm as it always did. Falling through on an unmapped flag costs the
+/// speedup, never the result.
+///
+/// The dependency axis follows npm's own contract: `--omit` and
+/// `--include` accumulate, `include` wins over `omit` whatever the order,
+/// `NODE_ENV=production` is an ambient `omit=dev` that `--include=dev` or
+/// `--production=false` overrides, and `omit=peer` is not something the
+/// engine does, so it falls through. Ignored, because they shape npm's
+/// output or its own cache rather than the tree: `--audit`, `--fund`,
+/// `--prefer-offline`, `--loglevel`, `--silent`, `--quiet`, `-s`, `-q`,
+/// `-d`/`-dd`/`-ddd`, `--progress`, `--color`, `--foreground-scripts`.
+pub fn npm_install_route(args: &[String], node_env_production: bool) -> Option<NpmEngineInstall> {
+    let mut verb: Option<NpmInstallVerb> = None;
+    let mut ignore_scripts: Option<bool> = None;
+    let (mut omit_dev, mut include_dev) = (node_env_production, false);
+    let (mut omit_optional, mut include_optional) = (false, false);
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        let (flag, value) = match arg.split_once('=') {
+            Some((f, v)) => (f, Some(v)),
+            None => (arg, None),
+        };
+        // `--omit dev` and `--loglevel warn`: the value as the next token
+        // when it was not attached.
+        let take_value = |i: &mut usize| -> Option<String> {
+            match value {
+                Some(v) => Some(v.to_string()),
+                None => {
+                    *i += 1;
+                    args.get(*i).cloned()
+                }
+            }
+        };
+        match flag {
+            "--ignore-scripts" => ignore_scripts = Some(npm_bool(value)?),
+            "--production" | "--prod" => {
+                if npm_bool(value)? {
+                    omit_dev = true;
+                } else {
+                    include_dev = true;
+                }
+            }
+            "--only" => match take_value(&mut i)?.as_str() {
+                "prod" | "production" => omit_dev = true,
+                _ => return None,
+            },
+            "--omit" => match take_value(&mut i)?.as_str() {
+                "dev" => omit_dev = true,
+                "optional" => omit_optional = true,
+                _ => return None,
+            },
+            "--include" => match take_value(&mut i)?.as_str() {
+                "dev" => include_dev = true,
+                "optional" => include_optional = true,
+                "prod" => {}
+                _ => return None,
+            },
+            "--no-optional" => omit_optional = true,
+            "--optional" => {
+                if npm_bool(value)? {
+                    include_optional = true;
+                } else {
+                    omit_optional = true;
+                }
+            }
+            "--audit" | "--fund" | "--prefer-offline" | "--progress" | "--foreground-scripts" => {
+                npm_bool(value)?;
+            }
+            "--loglevel" => {
+                take_value(&mut i)?;
+            }
+            "--no-audit" | "--no-fund" | "--silent" | "--quiet" | "-s" | "-q" | "-d" | "-dd"
+            | "-ddd" | "--no-progress" | "--color" | "--no-color" => {}
+            _ if flag.starts_with('-') => return None,
+            // npm's own alias table for the two verbs, `lib/utils/cmd-list.js`
+            // (npm 12.0.2) — the misspellings are npm's, not ours.
+            "ci" | "clean-install" | "ic" | "install-clean" | "isntall-clean" if verb.is_none() => {
+                verb = Some(NpmInstallVerb::Ci);
+            }
+            "install" | "add" | "i" | "in" | "ins" | "inst" | "insta" | "instal" | "isnt"
+            | "isnta" | "isntal" | "isntall"
+                if verb.is_none() =>
+            {
+                verb = Some(NpmInstallVerb::Install)
+            }
+            // A second positional is a package spec (`npm install react`) or
+            // a verb that is not an install.
+            _ => return None,
+        }
+        i += 1;
+    }
+    Some(NpmEngineInstall {
+        verb: verb?,
+        ignore_scripts,
+        prod: omit_dev && !include_dev,
+        no_optional: omit_optional && !include_optional,
+    })
+}
+
+/// npm's effective `ignore-scripts` outside the command line: the
+/// environment (`npm_config_ignore_scripts`, any letter case, as npm reads
+/// it) outranks the project `.npmrc`, which outranks the user's. A routed
+/// install honors it because npm would have, and the routed path otherwise
+/// runs every build script.
+pub fn npm_ignore_scripts_configured(project_root: &Path) -> bool {
+    if let Some((_, v)) =
+        std::env::vars().find(|(k, _)| k.eq_ignore_ascii_case("npm_config_ignore_scripts"))
+    {
+        return matches!(v.trim(), "true" | "1");
+    }
+    crate::workspace::scripts::npmrc_value(project_root, "ignore-scripts")
+        .is_some_and(|v| matches!(v.as_str(), "true" | "1"))
+}
+
 /// Whether this shim invocation was spawned by an already-running package
 /// manager (a nested call), versus typed by the user at a shell (a top-level
 /// call). Decides whether a NAME-MISMATCH is a hard refusal (top-level — the
@@ -1696,6 +1881,101 @@ mod tests {
     /// cleaned, PIDs recycle, and a recycled-PID run re-entering a stale
     /// sibling finds last run's links/files (the tests/pm_shim.rs `tmp` flake
     /// — see its doc for the full post-mortem).
+    fn route(args: &[&str]) -> Option<NpmEngineInstall> {
+        let args: Vec<String> = args.iter().map(|a| a.to_string()).collect();
+        npm_install_route(&args, false)
+    }
+
+    #[test]
+    fn npm_install_route_translates_the_install_verbs_and_falls_through_on_the_rest() {
+        let ci = route(&["ci"]).unwrap();
+        assert_eq!(ci.verb, NpmInstallVerb::Ci);
+        assert!(ci.ignore_scripts.is_none() && !ci.prod && !ci.no_optional);
+        for alias in ["clean-install", "ic", "install-clean", "isntall-clean"] {
+            assert_eq!(route(&[alias]).unwrap().verb, NpmInstallVerb::Ci, "{alias}");
+        }
+        for alias in ["i", "add", "in", "instal", "isntall"] {
+            assert_eq!(
+                route(&[alias]).unwrap().verb,
+                NpmInstallVerb::Install,
+                "{alias}"
+            );
+        }
+
+        // The flags CI workflows carry, translated or ignored.
+        let ava = route(&["install", "--no-audit", "--ignore-scripts"]).unwrap();
+        assert_eq!(ava.verb, NpmInstallVerb::Install);
+        assert_eq!(ava.ignore_scripts, Some(true));
+        assert_eq!(
+            route(&["ci", "--ignore-scripts=false"])
+                .unwrap()
+                .ignore_scripts,
+            Some(false)
+        );
+        assert!(route(&["ci", "--omit=dev"]).unwrap().prod);
+        assert!(route(&["ci", "--omit", "dev"]).unwrap().prod);
+        assert!(route(&["ci", "--production"]).unwrap().prod);
+        assert!(route(&["ci", "--only=prod"]).unwrap().prod);
+        assert!(route(&["ci", "--omit=optional"]).unwrap().no_optional);
+        assert!(route(&["ci", "--optional=false"]).unwrap().no_optional);
+        let ignored = route(&[
+            "ci",
+            "--no-fund",
+            "--audit=false",
+            "--prefer-offline",
+            "--loglevel",
+            "error",
+            "--loglevel=warn",
+        ])
+        .unwrap();
+        assert!(!ignored.prod && !ignored.no_optional && ignored.ignore_scripts.is_none());
+
+        // include wins over omit in either order, and over the ambient
+        // NODE_ENV=production; an explicit false is false.
+        assert!(!route(&["ci", "--omit=dev", "--include=dev"]).unwrap().prod);
+        assert!(!route(&["ci", "--include=dev", "--omit=dev"]).unwrap().prod);
+        assert!(
+            !route(&["ci", "--omit=optional", "--include=optional"])
+                .unwrap()
+                .no_optional
+        );
+        let env_prod = |argv: &[&str]| {
+            let args: Vec<String> = argv.iter().map(|a| a.to_string()).collect();
+            npm_install_route(&args, true).unwrap().prod
+        };
+        assert!(env_prod(&["ci"]), "NODE_ENV=production is npm's --omit=dev");
+        assert!(
+            !env_prod(&["install", "--production=false"]),
+            "--production=false restores dev"
+        );
+        assert!(!env_prod(&["ci", "--include=dev"]));
+
+        // Anything the engine cannot honor verbatim runs on the real npm.
+        for argv in [
+            vec!["install", "react"],
+            vec!["ci", "--legacy-peer-deps"],
+            vec!["ci", "--workspace=a"],
+            vec!["ci", "-w", "a"],
+            vec!["install", "--no-package-lock"],
+            vec!["ci", "--prefix", "sub"],
+            vec!["ci", "--omit=peer"],
+            vec!["ci", "--include=peer"],
+            vec!["ci", "--production=maybe"],
+            vec!["ci", "--ignore-scripts=yes"],
+            vec!["ci", "--only=dev"],
+            vec!["ci", "--loglevel"],
+            vec!["install", "-g", "npm"],
+            vec!["--version"],
+            vec!["run", "build"],
+            vec![],
+        ] {
+            assert!(
+                route(&argv).is_none(),
+                "{argv:?} must fall through to the real npm"
+            );
+        }
+    }
+
     fn tmpdir(tag: &str) -> PathBuf {
         static N: AtomicU64 = AtomicU64::new(0);
         static STARTED_NANOS: std::sync::OnceLock<u128> = std::sync::OnceLock::new();

--- a/site/content/docs/pm/pm-shim.mdx
+++ b/site/content/docs/pm/pm-shim.mdx
@@ -46,6 +46,27 @@ and node_modules.
 
 Runner commands fall through to the system tool whatever the pin — `npx`, `pnpx`, and the `init` / `create` / `dlx` / `exec` verbs — so `npm create vite` works in a pnpm project. A package manager spawned by a running install — a lifecycle script shelling out to a different one — also falls through, so an install you never typed directly isn't broken.
 
+## Running npm installs on Nub's engine
+
+The shims run the package manager the project pins. One opt-in changes that for the two npm verbs an install pipeline runs:
+
+```sh
+nub pm shim --route-installs
+```
+
+With the marker set, a bare `npm ci` in a project with a `package-lock.json` runs `nub ci`, and a bare `npm install` runs `nub install`, both on Nub's engine and from the same lockfile. The notice on stderr names the swap:
+
+```console
+$ npm ci
+npm ci → nub ci (via nub shim)
+```
+
+The rest of npm is untouched. Everything else runs the real npm with the argv as typed: `npm test`, `npm run`, `npx`, `npm publish`, a global install, an install that names a package, and an install with a flag Nub does not translate (`--legacy-peer-deps`, `--workspace`, `--prefix`, `--no-package-lock`). So does an `npm install` a lifecycle script spawns under a running install. Translated flags: `--ignore-scripts`, `--omit=dev` (also `--production` and `NODE_ENV=production`), `--omit=optional`, and `--include`, which wins over `--omit` in either order as it does for npm; `--no-audit`, `--no-fund`, `--prefer-offline`, and the log-level and progress flags are accepted and ignored.
+
+A routed install runs every lifecycle script, as npm does, and hands them `NODE_ENV=production` exactly when dev dependencies are omitted. An `ignore-scripts=true` in the project or user `.npmrc`, or `npm_config_ignore_scripts` in the environment, is honored, and `--ignore-scripts=false` on the command line outranks it. The default trust list still applies to `nub install` typed directly.
+
+`nub pm shim --no-route-installs` turns the routing off and keeps the shims; `nub pm unshim` removes both.
+
 ## Missing system manager
 
 An unpinned invocation falls through to the system manager. When there is none — a fresh machine, a minimal container — the shim runs a dynamic default instead of failing: the version family the committed lockfile implies, or the registry `latest` when there is no lockfile. It announces the choice on stderr and writes no pin. The `latest` resolution is remembered for 24 hours, so repeat invocations dispatch with no registry round-trip, and when the registry is unreachable the last resolved version keeps working.

--- a/vendor/aube/crates/aube/src/commands/install/finalize.rs
+++ b/vendor/aube/crates/aube/src/commands/install/finalize.rs
@@ -4,7 +4,8 @@ use super::bin_linking::{
 };
 use super::dep_selection::DepSelection;
 use super::lifecycle::{
-    JailBuildPolicy, run_dep_lifecycle_scripts, run_importer_lifecycle, unreviewed_dep_builds,
+    JailBuildPolicy, run_dep_lifecycle_scripts, run_importer_lifecycle, run_link_lifecycle_scripts,
+    trash_failed_optional_links, unreviewed_dep_builds,
 };
 use super::side_effects_cache::{
     SideEffectsCacheConfig, SideEffectsCacheLocation, side_effects_cache_root,
@@ -55,6 +56,9 @@ pub(super) struct FinalizePhaseInput<'a> {
     pub(super) strict_dep_builds_setting: bool,
     pub(super) ignore_scripts: bool,
     pub(super) skip_root_lifecycle: bool,
+    /// The lockfile read was npm's, so a `file:` directory link carries
+    /// npm's link build pass ([`run_link_lifecycle_scripts`]).
+    pub(super) npm_link_lifecycle: bool,
     pub(super) workspace_filter_empty: bool,
     pub(super) dep_selection: DepSelection,
     pub(super) cli_flags: &'a [(String, String)],
@@ -242,6 +246,7 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         strict_dep_builds_setting,
         ignore_scripts,
         skip_root_lifecycle,
+        npm_link_lifecycle,
         workspace_filter_empty,
         dep_selection,
         cli_flags,
@@ -253,6 +258,39 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
     } = input;
 
     let placements_ref = stats.hoisted_placements.as_ref();
+
+    // Regenerate every `.bin/` shim against post-build targets. A build can
+    // replace a bin — a JS launcher becomes a native binary (esbuild, #394)
+    // — and the link phase shimmed it as `node <target>` before any script
+    // ran, so the shim now wraps a native binary and fails; and a bin a
+    // link's `prepare` generates did not exist to shim at all.
+    // `create_bin_shim` re-classifies each target and emits a direct-exec
+    // symlink/wrapper for the ones that turned native. Shared by the
+    // dependency build pass and npm's link build pass below.
+    let relink_bins = |graph: &aube_lockfile::LockfileGraph| -> miette::Result<()> {
+        let preserved = remove_managed_bin_links(managed_bin_links)?;
+        let relinked = link_all_bins(LinkAllBinsInput {
+            project_dir: cwd,
+            settings_ctx,
+            modules_dir_name,
+            aube_dir,
+            graph,
+            virtual_store_dir_max_length,
+            placements: placements_ref,
+            ws_dirs,
+            manifests,
+            manifest,
+            node_linker,
+            has_workspace,
+            virtual_store_only,
+            ignore_scripts,
+            has_any_allow_rule: build_policy.has_any_allow_rule(),
+            floor_may_allow_any: default_trust_floor.may_allow_any(),
+            preserved: Some(&preserved),
+        })?;
+        remove_unclaimed_preserved_bin_links(managed_bin_links, &preserved, &relinked)?;
+        Ok(())
+    };
 
     // Tear down the progress display before running post-link lifecycle
     // scripts or printing the final summary — scripts write directly to
@@ -399,41 +437,46 @@ pub(super) async fn run_finalize_phase(input: FinalizePhaseInput<'_>) -> miette:
         }
         phase_timings.record("dep_lifecycle", phase_start.elapsed());
 
-        // Regenerate every `.bin/` shim against the post-build targets. A
-        // build can replace a bin — a JS launcher becomes a native binary
-        // (esbuild, #394) — and the link phase shimmed it as `node <target>`
-        // before this phase ran, so the shim now wraps a native binary and
-        // fails. `create_bin_shim` re-classifies each target and emits a
-        // direct-exec symlink/wrapper for the ones that turned native.
-        //
         // Gated on `package_contents_changed`, NOT on the script count: a
         // `sideEffectsCache` restore (default on) recreates the package dir
         // with the already-native bin and returns a zero script count, yet
         // still needs the shim regenerated.
         if lifecycle_outcome.package_contents_changed {
             let phase_start = std::time::Instant::now();
-            let preserved = remove_managed_bin_links(managed_bin_links)?;
-            let relinked = link_all_bins(LinkAllBinsInput {
-                project_dir: cwd,
-                settings_ctx,
-                modules_dir_name,
-                aube_dir,
-                graph: graph_for_link,
-                virtual_store_dir_max_length,
-                placements: placements_ref,
-                ws_dirs,
-                manifests,
-                manifest,
-                node_linker,
-                has_workspace,
-                virtual_store_only,
-                ignore_scripts,
-                has_any_allow_rule: build_policy.has_any_allow_rule(),
-                floor_may_allow_any: default_trust_floor.may_allow_any(),
-                preserved: Some(&preserved),
-            })?;
-            remove_unclaimed_preserved_bin_links(managed_bin_links, &preserved, &relinked)?;
+            relink_bins(graph_for_link)?;
             tracing::debug!("phase:relink_bins {:.1?}", phase_start.elapsed());
+            phase_timings.record("relink_bins", phase_start.elapsed());
+        }
+    }
+
+    // 7a. npm's link build pass, between the dependency builds and the
+    //     root's own hooks, where npm runs it. Same gates as 7b, minus the
+    //     root-lifecycle skip: a link target is not the root.
+    if npm_link_lifecycle && !ignore_scripts && !virtual_store_only {
+        let phase_start = std::time::Instant::now();
+        let outcome =
+            run_link_lifecycle_scripts(cwd, modules_dir_name, graph_for_link, lifecycle_manifests)
+                .await?;
+        phase_timings.record("link_lifecycle", phase_start.elapsed());
+        if !outcome.failed_optional.is_empty() {
+            // A failed optional link leaves the tree, its bins with it, and
+            // the state write below carries it as not attempted so the next
+            // install retries the build.
+            let mut pruned = graph_for_link.clone();
+            trash_failed_optional_links(
+                cwd,
+                modules_dir_name,
+                &mut pruned,
+                &outcome.failed_optional,
+            )?;
+            builds_not_attempted
+                .extend(outcome.failed_optional.iter().map(|link| link.spec.clone()));
+            let phase_start = std::time::Instant::now();
+            relink_bins(&pruned)?;
+            phase_timings.record("relink_bins", phase_start.elapsed());
+        } else if outcome.ran {
+            let phase_start = std::time::Instant::now();
+            relink_bins(graph_for_link)?;
             phase_timings.record("relink_bins", phase_start.elapsed());
         }
     }

--- a/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
+++ b/vendor/aube/crates/aube/src/commands/install/lifecycle.rs
@@ -48,6 +48,204 @@ pub(super) async fn run_importer_lifecycle(
     Ok(())
 }
 
+/// npm's link build pass (`Arborist#build(linkNodes, { type: 'links' })`
+/// in `rebuild.js`): a `file:` directory dependency is a symlink to a
+/// directory the project owns, and npm runs its `preinstall` → `prepare` →
+/// `install` → `postinstall` there, one hook across every link before the
+/// next — the shape of a workspace member's own hooks rather than a
+/// dependency build, so no build policy, no jail, no side-effects cache.
+/// Two things npm's build set does for a link carry over: a target with a
+/// `binding.gyp` and no install hook gets the implicit `node-gyp rebuild`
+/// (`#addToBuildSet`, the same synthesis the dependency pass applies), and a
+/// link reachable only through `optionalDependencies` fails its own scripts
+/// without failing the install (`_handleOptionalFailure`, which trashes the
+/// node — the caller removes its links and keeps its bins out, so code that
+/// falls back on the module's absence gets the fallback rather than a
+/// half-built package). npm links bins between `prepare` and `install`;
+/// here the caller regenerates every bin once the pass has run, which is
+/// what makes a bin `prepare` generated resolve.
+///
+/// Only an npm lockfile links a `file:` directory (pnpm copies it into the
+/// store and builds the copy as a dependency; a `link:` is scriptless in
+/// every manager), so the caller gates on the incumbent. A directory whose
+/// hooks already run as an importer's — the root and each workspace member,
+/// `importers` here — is excluded; the graph's own importer set is not the
+/// test, because the npm reader keeps every link target as an importer when
+/// the manifest declares no `workspaces`. So is a directory with no
+/// `package.json` to name a script.
+pub(super) async fn run_link_lifecycle_scripts(
+    project_dir: &std::path::Path,
+    modules_dir_name: &str,
+    graph: &aube_lockfile::LockfileGraph,
+    importers: &[(String, aube_manifest::PackageJson)],
+) -> miette::Result<LinkLifecycleOutcome> {
+    struct LinkTarget {
+        spec: String,
+        dep_paths: Vec<String>,
+        manifest: aube_manifest::PackageJson,
+        optional: bool,
+    }
+    let optional_only = aube_resolver::platform::optional_only_packages(graph);
+    let mut links: std::collections::BTreeMap<std::path::PathBuf, LinkTarget> =
+        std::collections::BTreeMap::new();
+    for (dep_path, pkg) in &graph.packages {
+        let Some(aube_lockfile::LocalSource::Link(path)) = &pkg.local_source else {
+            continue;
+        };
+        if let Some(link) = links.get_mut(path) {
+            // The same directory linked under two names: one build, and
+            // every graph key it answers to when the build fails.
+            link.dep_paths.push(dep_path.clone());
+            link.optional &= optional_only.contains(dep_path);
+            continue;
+        }
+        if importers
+            .iter()
+            .any(|(importer, _)| std::path::Path::new(importer) == path.as_path())
+        {
+            continue;
+        }
+        let target = project_dir.join(path);
+        let manifest_path = target.join("package.json");
+        let Ok(content) = std::fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let mut manifest = aube_manifest::PackageJson::parse(&manifest_path, content)
+            .map_err(miette::Report::new)
+            .wrap_err_with(|| format!("failed to parse {}", manifest_path.display()))?;
+        if let Some(script) = aube_scripts::default_install_script(&target, &manifest) {
+            manifest.scripts.insert(
+                aube_scripts::LifecycleHook::Install
+                    .script_name()
+                    .to_string(),
+                script.to_string(),
+            );
+        }
+        links.insert(
+            path.clone(),
+            LinkTarget {
+                spec: format!("{}@{}", pkg.name, pkg.version),
+                dep_paths: vec![dep_path.clone()],
+                manifest,
+                optional: optional_only.contains(dep_path),
+            },
+        );
+    }
+    const HOOKS: [aube_scripts::LifecycleHook; 4] = [
+        aube_scripts::LifecycleHook::PreInstall,
+        aube_scripts::LifecycleHook::Prepare,
+        aube_scripts::LifecycleHook::Install,
+        aube_scripts::LifecycleHook::PostInstall,
+    ];
+    let has_work = |link: &LinkTarget| {
+        HOOKS
+            .iter()
+            .any(|hook| link.manifest.scripts.contains_key(hook.script_name()))
+    };
+    if !links.values().any(has_work) {
+        return Ok(LinkLifecycleOutcome::default());
+    }
+    tracing::debug!("phase:link_lifecycle {} linked directories", links.len());
+    let mut failed: std::collections::BTreeSet<std::path::PathBuf> =
+        std::collections::BTreeSet::new();
+    for hook in HOOKS {
+        for (path, link) in &links {
+            if failed.contains(path) {
+                continue;
+            }
+            let label = path.to_string_lossy();
+            let result = run_importer_lifecycle(
+                project_dir,
+                &project_dir.join(path),
+                &label,
+                modules_dir_name,
+                &link.manifest,
+                hook,
+            )
+            .await;
+            match result {
+                Ok(()) => {}
+                Err(error) if link.optional => {
+                    tracing::warn!(
+                        code = aube_codes::warnings::WARN_AUBE_OPTIONAL_BUILD_FAILED,
+                        "{} is an optional dependency and failed to build; continuing without it: {error}",
+                        link.spec
+                    );
+                    failed.insert(path.clone());
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+    let failed_optional = failed
+        .iter()
+        .map(|path| {
+            let link = &links[path];
+            FailedOptionalLink {
+                spec: link.spec.clone(),
+                dep_paths: link.dep_paths.clone(),
+            }
+        })
+        .collect();
+    Ok(LinkLifecycleOutcome {
+        ran: true,
+        failed_optional,
+    })
+}
+
+/// What [`run_link_lifecycle_scripts`] did: whether any script ran (a bin
+/// relink is then due), and the optional-only links whose scripts failed.
+#[derive(Debug, Default)]
+pub(super) struct LinkLifecycleOutcome {
+    pub ran: bool,
+    pub failed_optional: Vec<FailedOptionalLink>,
+}
+
+#[derive(Debug)]
+pub(super) struct FailedOptionalLink {
+    /// `name@version`, the key the state file records so the next install
+    /// retries the build instead of sealing the tree.
+    pub spec: String,
+    /// Every graph key the directory was linked under.
+    pub dep_paths: Vec<String>,
+}
+
+/// npm's trash for an optional node whose build failed: unlink it from
+/// every importer that placed it, and take it out of `graph` so the bin
+/// relink that follows never shims it. A `file:` link is only ever an
+/// importer's direct dependency (a published package cannot name a local
+/// directory), so the importers' own `node_modules` are the whole set of
+/// placements. Only a link is removed — a symlink, or the NTFS junction
+/// `aube_linker::sys::create_dir_link` makes on Windows, which reports as a
+/// directory rather than a symlink — never a real directory at that name,
+/// and never the link's target.
+pub(super) fn trash_failed_optional_links(
+    project_dir: &std::path::Path,
+    modules_dir_name: &str,
+    graph: &mut aube_lockfile::LockfileGraph,
+    failed: &[FailedOptionalLink],
+) -> miette::Result<()> {
+    for link in failed {
+        for dep_path in &link.dep_paths {
+            for (importer_path, deps) in graph.importers.iter_mut() {
+                let importer_dir =
+                    super::workspace::importer_project_dir(project_dir, importer_path);
+                for dep in deps.iter().filter(|dep| &dep.dep_path == dep_path) {
+                    let placement = importer_dir.join(modules_dir_name).join(&dep.name);
+                    if let Ok(metadata) = std::fs::symlink_metadata(&placement)
+                        && crate::commands::fs_helpers::is_link_or_junction_metadata(&metadata)
+                    {
+                        crate::commands::fs_helpers::remove_existing(&placement)?;
+                    }
+                }
+                deps.retain(|dep| &dep.dep_path != dep_path);
+            }
+            graph.packages.remove(dep_path);
+        }
+    }
+    Ok(())
+}
+
 /// Run a named root-package lifecycle script.
 ///
 /// Most install hooks use [`aube_scripts::LifecycleHook`], but pnpm's
@@ -510,6 +708,15 @@ pub(crate) async fn run_dep_lifecycle_scripts(
         if let Some(selected) = selected_dep_paths
             && !selected.contains(dep_path)
         {
+            continue;
+        }
+        // A linked directory is a symlink to its source, never a store
+        // entry, so it is not a dependency build: the on-disk check below
+        // could only ever warn for it (and did, under an allow-all policy).
+        // Its scripts are its own — a workspace member's run as an
+        // importer's, and a `file:` link's run in
+        // [`run_link_lifecycle_scripts`], npm's link build pass.
+        if matches!(pkg.local_source, Some(aube_lockfile::LocalSource::Link(_))) {
             continue;
         }
         // True when this package runs only because the `defaultTrust`
@@ -1674,6 +1881,94 @@ pub(super) fn unreviewed_dep_builds(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The trash removes the link the linker itself makes — a symlink, or
+    /// the junction on Windows — from every importer that placed it, leaves
+    /// the link's target and a real directory of the same shape alone, and
+    /// prunes the graph the bin relink reads.
+    #[test]
+    fn trash_failed_optional_links_removes_the_placement_link_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path();
+        let target = project.join("opt-dep");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("package.json"), "{}").unwrap();
+        let modules = project.join("node_modules");
+        std::fs::create_dir_all(modules.join("real-dir")).unwrap();
+        aube_linker::sys::create_dir_link(&target, &modules.join("opt-dep")).unwrap();
+        // A member that placed the same link under its own node_modules.
+        let member_modules = project.join("packages/a/node_modules");
+        std::fs::create_dir_all(&member_modules).unwrap();
+        aube_linker::sys::create_dir_link(&target, &member_modules.join("opt-dep")).unwrap();
+
+        let dep = |name: &str, dep_path: &str| aube_lockfile::DirectDep {
+            name: name.to_string(),
+            dep_path: dep_path.to_string(),
+            dep_type: aube_lockfile::DepType::Optional,
+            specifier: None,
+        };
+        let mut graph = aube_lockfile::LockfileGraph::default();
+        graph.importers.insert(
+            ".".to_string(),
+            vec![
+                dep("opt-dep", "opt-dep@link+opt-dep"),
+                dep("real-dir", "real-dir@1.0.0"),
+            ],
+        );
+        graph.importers.insert(
+            "packages/a".to_string(),
+            vec![dep("opt-dep", "opt-dep@link+opt-dep")],
+        );
+        for (dep_path, name) in [
+            ("opt-dep@link+opt-dep", "opt-dep"),
+            ("real-dir@1.0.0", "real-dir"),
+        ] {
+            graph.packages.insert(
+                dep_path.to_string(),
+                aube_lockfile::LockedPackage {
+                    name: name.to_string(),
+                    version: "1.0.0".to_string(),
+                    dep_path: dep_path.to_string(),
+                    ..Default::default()
+                },
+            );
+        }
+
+        trash_failed_optional_links(
+            project,
+            "node_modules",
+            &mut graph,
+            &[FailedOptionalLink {
+                spec: "opt-dep@1.0.0".to_string(),
+                dep_paths: vec!["opt-dep@link+opt-dep".to_string()],
+            }],
+        )
+        .unwrap();
+
+        assert!(
+            modules.join("opt-dep").symlink_metadata().is_err()
+                && member_modules.join("opt-dep").symlink_metadata().is_err(),
+            "both placements of the failed link are gone"
+        );
+        assert!(
+            target.join("package.json").is_file(),
+            "the link's target directory is untouched"
+        );
+        assert!(
+            modules.join("real-dir").is_dir(),
+            "a real directory is not a link and stays"
+        );
+        assert!(!graph.packages.contains_key("opt-dep@link+opt-dep"));
+        assert!(graph.packages.contains_key("real-dir@1.0.0"));
+        assert!(
+            graph
+                .importers
+                .values()
+                .flatten()
+                .all(|dep| dep.name != "opt-dep"),
+            "every importer edge to the failed link is pruned"
+        );
+    }
 
     #[tokio::test]
     async fn global_virtual_store_lifecycle_uses_physical_package_dir() {

--- a/vendor/aube/crates/aube/src/commands/install/mod.rs
+++ b/vendor/aube/crates/aube/src/commands/install/mod.rs
@@ -3085,6 +3085,7 @@ async fn run_inner(opts: InstallOptions, cwd: std::path::PathBuf) -> miette::Res
         strict_dep_builds_setting,
         ignore_scripts: opts.ignore_scripts,
         skip_root_lifecycle: opts.skip_root_lifecycle,
+        npm_link_lifecycle: matches!(source_kind_before, Some(aube_lockfile::LockfileKind::Npm)),
         workspace_filter_empty: opts.workspace_filter.is_empty(),
         dep_selection: opts.dep_selection,
         cli_flags: &opts.cli_flags,


### PR DESCRIPTION
The shims run the manager the project pins, so a bare `npm ci` under them is still npm's install. With `nub pm shim --route-installs` the `npm` shim runs `npm ci` as `nub ci` and a bare `npm install` as `nub install --no-frozen-lockfile`, from the project's own `package-lock.json`, and says so on stderr. Only those verbs, only the flags the engine honors verbatim, only at top level, only with an npm lockfile; any other argv reaches the real npm untouched. The default is unchanged; `--no-route-installs` turns it off.

npm's script semantics carry over: `ignore-scripts` from the environment and `.npmrc` (the command line outranks both), explicit boolean values, `--include` over `--omit` in either order, and `NODE_ENV=production` for lifecycle scripts when dev is omitted.

Engine: npm's link build pass. A `file:` directory dependency's `preinstall`/`prepare`/`install`/`postinstall` now run in the link target on an npm-lockfile install, as npm runs them: the implicit `node-gyp rebuild` for a `binding.gyp` target, bins relinked after the pass, and a link reachable only through `optionalDependencies` whose scripts fail leaves the tree with its bins (npm trashes the node) and is retried on the next install. The dependency build loop no longer reaches a link.

Docs: the shim page.