### PR TITLE
pm: accept a bun-style source identity as a patchedDependencies key

### DIFF
--- a/vendor/aube/crates/aube-lockfile/src/bun/read.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/read.rs
@@ -3,9 +3,10 @@ use super::raw::{BunEntry, RawBunLockfile};
 use super::source::{
     bin_value_to_map, bun_key_to_alias_name, classify_bun_ident,
     rebase_workspace_scoped_local_source, resolve_nested_bun, resolve_workspace_dep, split_ident,
-    unrecognized_protocol,
 };
-use crate::{DepType, DirectDep, Error, LockedPackage, LockfileGraph, PeerDepMeta};
+use crate::{
+    DepType, DirectDep, Error, LockedPackage, LockfileGraph, PeerDepMeta, version_protocol,
+};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
@@ -116,12 +117,15 @@ pub fn parse(path: &Path) -> Result<LockfileGraph, Error> {
             &workspace_dirs,
         )?;
         // A protocol-shaped tail that fell through the classifier means a
-        // source this reader can't resolve. Withhold the entry so the edge
-        // sites below fatal / warn+skip instead of resolving to a bogus
-        // registry pin.
+        // source this reader can't resolve — an unknown or future bun
+        // protocol, or a malformed spec like a `git+…` tail
+        // `parse_git_spec` rejected. Withhold the entry so the edge sites
+        // below fatal / warn+skip instead of resolving to a bogus registry
+        // pin. Consulted only under `strict_unsupported_source`; the
+        // lenient default keeps the historical reclassify behavior.
         if strict
             && local_source.is_none()
-            && let Some(protocol) = unrecognized_protocol(&raw_version)
+            && let Some(protocol) = version_protocol(&raw_version)
         {
             unsupported.insert(
                 key.clone(),

--- a/vendor/aube/crates/aube-lockfile/src/bun/source.rs
+++ b/vendor/aube/crates/aube-lockfile/src/bun/source.rs
@@ -162,27 +162,6 @@ pub(super) fn classify_bun_ident(
     Ok((name, raw_version.to_string(), None, alias_of))
 }
 
-/// The protocol token of a version tail that reached
-/// [`classify_bun_ident`]'s registry-pin fall-through while carrying a
-/// `<token>:` protocol prefix — i.e. a source the classifier has no
-/// branch for (an unknown/future bun protocol, or a malformed spec like
-/// a `git+…` tail `parse_git_spec` rejected). A genuine registry pin is
-/// an exact semver version, which can never contain `:`, so a
-/// protocol-shaped tail here means "unresolvable from this lockfile",
-/// not "registry". Consulted only under `strict_unsupported_source`;
-/// the lenient default keeps the historical reclassify-to-registry
-/// behavior without ever calling this.
-pub(super) fn unrecognized_protocol(raw_version: &str) -> Option<&str> {
-    let token = &raw_version[..raw_version.find(':')?];
-    let mut chars = token.chars();
-    if !chars.next()?.is_ascii_alphabetic() {
-        return None;
-    }
-    chars
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
-        .then_some(token)
-}
-
 pub(super) fn rebase_workspace_scoped_local_source(
     key: &str,
     local: LocalSource,

--- a/vendor/aube/crates/aube-lockfile/src/lib.rs
+++ b/vendor/aube/crates/aube-lockfile/src/lib.rs
@@ -377,6 +377,32 @@ pub(crate) struct UnsupportedSpec {
     pub protocol: String,
 }
 
+/// The `<token>:` protocol prefix of a version tail, if it carries one.
+///
+/// A registry pin is an exact semver version, which can never contain a
+/// `:`, so a protocol-shaped tail marks a NON-registry source —
+/// `github:owner/repo#sha`, `git+ssh://…`, `file:./vendor`,
+/// `https://…/pkg.tgz`, `workspace:*`. Every non-registry branch of the
+/// bun reader's `classify_bun_ident` records that whole tail verbatim as
+/// [`LockedPackage::version`], so the same predicate answers two
+/// questions: whether a lockfile ident is resolvable as a registry pin,
+/// and whether a `patchedDependencies` selector is a source identity
+/// rather than a malformed semver range.
+///
+/// Deliberately narrow — the token must start with a letter and hold
+/// only `[A-Za-z0-9+.-]` — so a typo like `^^1:2` is not read as a
+/// protocol and keeps erroring where it should.
+pub(crate) fn version_protocol(raw_version: &str) -> Option<&str> {
+    let token = &raw_version[..raw_version.find(':')?];
+    let mut chars = token.chars();
+    if !chars.next()?.is_ascii_alphabetic() {
+        return None;
+    }
+    chars
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+        .then_some(token)
+}
+
 /// Resolve a dependency `spec` against the lockfile's `spec → dep_path`
 /// index, applying the abort-eagerly policy for specs a classifier
 /// recorded as an [`UnsupportedSpec`]. Returns the resolved dep_path,

--- a/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
+++ b/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
@@ -114,7 +114,50 @@ fn split_name_selector(key: &str) -> Option<(&str, &str)> {
 /// the tail verbatim as [`crate::LockedPackage::version`] — so such a
 /// key classifies as `Exact` and matches through the existing exact
 /// lookup with nothing else to teach the resolver.
+///
+/// **That shape is bun's, and it does not travel.** A key declared
+/// anywhere but bun's own field — the branded `pnpm.*` object, this
+/// tool's namespace, `pnpm-workspace.yaml` — is pnpm grammar and must
+/// keep failing exactly where pnpm fails, so those sources validate
+/// through [`classify_pnpm_patch_key`] as they are read. This function
+/// is the permissive one: it takes the merged declared set and the keys
+/// a lockfile already recorded, both of which may hold either grammar by
+/// then, and refusing a key a lockfile already contains would reject the
+/// lockfile rather than the declaration.
 pub fn classify_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRange> {
+    match classify_pnpm_patch_key(key) {
+        Err(invalid) => {
+            // Reached only once pnpm's own grammar has already rejected
+            // the selector, so no key that classifies today changes
+            // classification. A semver range cannot contain a `:`, so the
+            // two shapes cannot overlap either way, and the gate is a
+            // protocol TOKEN rather than the presence of a colon, so
+            // `foo@^^1:2` still errors.
+            let Some((name, selector)) = split_name_selector(key) else {
+                return Err(invalid);
+            };
+            if crate::version_protocol(selector).is_some() {
+                return Ok(PatchKeyForm::Exact {
+                    name,
+                    version: selector,
+                });
+            }
+            Err(invalid)
+        }
+        ok => ok,
+    }
+}
+
+/// Classify one `patchedDependencies` key under **pnpm's grammar only**,
+/// the way `groupPatchedDependencies` does: `dp.parse` splits the key,
+/// an exact semver version is `Exact`, and everything else must satisfy
+/// `validRange` or throw `PATCH_NON_SEMVER_RANGE`.
+///
+/// Kept separate from [`classify_patch_key`] because bun's source-identity
+/// key shape is not a fifth key shape in general — it is bun's, and a
+/// pnpm-origin declaration that carries one has to keep failing with
+/// pnpm's own message.
+pub fn classify_pnpm_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRange> {
     let Some((name, selector)) = split_name_selector(key) else {
         return Ok(PatchKeyForm::All { name: key });
     };
@@ -127,16 +170,6 @@ pub fn classify_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRan
         });
     }
     if node_semver::Range::parse(selector).is_err() {
-        // Checked only once the range parse has already failed, so no
-        // selector that classifies today changes classification. A
-        // semver range cannot contain a `:`, so the two shapes cannot
-        // overlap either way.
-        if crate::version_protocol(selector).is_some() {
-            return Ok(PatchKeyForm::Exact {
-                name,
-                version: selector,
-            });
-        }
         return Err(InvalidPatchRange {
             range: selector.to_string(),
         });
@@ -481,6 +514,55 @@ mod tests {
         assert_eq!(
             classify_patch_key("foo@^^1:2").unwrap_err().message(),
             "^^1:2 is not a valid semantic version range."
+        );
+    }
+
+    #[test]
+    fn pnpm_grammar_still_refuses_a_source_identity() {
+        // The shape is bun's and must not travel: pnpm's own
+        // `groupPatchedDependencies` runs `validRange` and throws
+        // `PATCH_NON_SEMVER_RANGE`, so a key read from
+        // `pnpm.patchedDependencies` or `pnpm-workspace.yaml` has to fail
+        // with pnpm's message even though the permissive classifier takes
+        // it.
+        for key in [
+            "is-positive@file:./vendor",
+            "ghostty-web@github:anomalyco/ghostty-web#83c0a07",
+        ] {
+            assert!(classify_patch_key(key).is_ok(), "bun grammar takes {key:?}");
+            assert!(
+                classify_pnpm_patch_key(key).is_err(),
+                "pnpm grammar must refuse {key:?}"
+            );
+        }
+        assert_eq!(
+            classify_pnpm_patch_key("is-positive@file:./vendor")
+                .unwrap_err()
+                .message(),
+            "file:./vendor is not a valid semantic version range."
+        );
+        // Every shape pnpm does have is unchanged by the split.
+        assert_eq!(
+            classify_pnpm_patch_key("foo@1.2.3").unwrap(),
+            PatchKeyForm::Exact {
+                name: "foo",
+                version: "1.2.3"
+            }
+        );
+        assert_eq!(
+            classify_pnpm_patch_key("foo@>=1").unwrap(),
+            PatchKeyForm::Range {
+                name: "foo",
+                range: ">=1"
+            }
+        );
+        assert_eq!(
+            classify_pnpm_patch_key("foo@*").unwrap(),
+            PatchKeyForm::All { name: "foo" }
+        );
+        assert_eq!(
+            classify_pnpm_patch_key("foo").unwrap(),
+            PatchKeyForm::All { name: "foo" }
         );
     }
 

--- a/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
+++ b/vendor/aube/crates/aube-lockfile/src/patch_groups.rs
@@ -101,6 +101,19 @@ fn split_name_selector(key: &str) -> Option<(&str, &str)> {
 /// semver version → `Exact`; otherwise a valid range → `All` when it
 /// trims to `*`, else `Range`; an invalid non-`*` selector errors; a
 /// bare/empty-selector key → `All`.
+///
+/// One selector shape reaches further than pnpm's grammar: a
+/// `<protocol>:` tail. pnpm rejects it, bun accepts it, and a bun
+/// project in the wild uses it — opencode patches
+/// `ghostty-web@github:anomalyco/ghostty-web#83c0a07`. Bun does not
+/// parse these keys at all: `Package.rs` hashes the whole key and
+/// `patchPackage.rs` looks a package up under `<name>@<resolution>`, so
+/// the key is an exact-match token over the package's resolved identity.
+/// That identity is exactly what this crate already stores — every
+/// non-registry branch of the bun reader's `classify_bun_ident` records
+/// the tail verbatim as [`crate::LockedPackage::version`] — so such a
+/// key classifies as `Exact` and matches through the existing exact
+/// lookup with nothing else to teach the resolver.
 pub fn classify_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRange> {
     let Some((name, selector)) = split_name_selector(key) else {
         return Ok(PatchKeyForm::All { name: key });
@@ -114,6 +127,16 @@ pub fn classify_patch_key(key: &str) -> Result<PatchKeyForm<'_>, InvalidPatchRan
         });
     }
     if node_semver::Range::parse(selector).is_err() {
+        // Checked only once the range parse has already failed, so no
+        // selector that classifies today changes classification. A
+        // semver range cannot contain a `:`, so the two shapes cannot
+        // overlap either way.
+        if crate::version_protocol(selector).is_some() {
+            return Ok(PatchKeyForm::Exact {
+                name,
+                version: selector,
+            });
+        }
         return Err(InvalidPatchRange {
             range: selector.to_string(),
         });
@@ -428,6 +451,60 @@ mod tests {
         assert_eq!(
             err.message(),
             "not-a-range is not a valid semantic version range."
+        );
+    }
+
+    #[test]
+    fn classify_a_source_protocol_selector_as_an_exact_identity() {
+        // Bun's grammar: the selector is the package's resolved identity,
+        // not a version range. Real case — opencode declares
+        // `ghostty-web@github:anomalyco/ghostty-web#83c0a07`, which
+        // errored with ERR_NUB_PATCH_NON_SEMVER_RANGE and refused the
+        // whole install.
+        assert_eq!(
+            classify_patch_key("ghostty-web@github:anomalyco/ghostty-web#83c0a07").unwrap(),
+            PatchKeyForm::Exact {
+                name: "ghostty-web",
+                version: "github:anomalyco/ghostty-web#83c0a07",
+            }
+        );
+        assert_eq!(
+            classify_patch_key("pkg@file:./vendor/pkg").unwrap(),
+            PatchKeyForm::Exact {
+                name: "pkg",
+                version: "file:./vendor/pkg",
+            }
+        );
+        // The gate is a protocol TOKEN, not the presence of a colon, so a
+        // typo stays an error rather than becoming a key that silently
+        // matches nothing.
+        assert_eq!(
+            classify_patch_key("foo@^^1:2").unwrap_err().message(),
+            "^^1:2 is not a valid semantic version range."
+        );
+    }
+
+    #[test]
+    fn resolve_matches_a_git_resolution_the_way_the_bun_reader_records_it() {
+        // `classify_bun_ident` stores a non-registry tail verbatim as the
+        // package's version, so the existing exact lookup is what matches
+        // the key — nothing in the resolver needed teaching.
+        let groups =
+            PatchGroups::build(["ghostty-web@github:anomalyco/ghostty-web#83c0a07"].into_iter())
+                .unwrap();
+        assert_eq!(
+            groups
+                .resolve("ghostty-web", "github:anomalyco/ghostty-web#83c0a07")
+                .unwrap(),
+            Some("ghostty-web@github:anomalyco/ghostty-web#83c0a07")
+        );
+        // A different commit of the same repository is a different
+        // package, and must not pick up the patch.
+        assert_eq!(
+            groups
+                .resolve("ghostty-web", "github:anomalyco/ghostty-web#deadbee")
+                .unwrap(),
+            None
         );
     }
 

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -14,7 +14,8 @@ use std::path::{Path, PathBuf};
 
 /// One resolved patch entry. `key` is the VERBATIM declared
 /// `patchedDependencies` key — exact (`ms@2.1.3`), range (`ms@>=2`),
-/// wildcard (`ms@*`), or bare name (`ms`) — and is the string the
+/// wildcard (`ms@*`), bare name (`ms`), or a source identity
+/// (`pkg@github:owner/repo#sha`) — and is the string the
 /// lockfile's `patchedDependencies:` block records unresolved, matching
 /// pnpm. `path` is the absolute path on disk, `content` is the raw
 /// patch text the linker applies. Mapping a concrete resolved
@@ -77,11 +78,13 @@ pub(crate) fn is_safe_patch_rel(rel: &str) -> bool {
 }
 
 /// Validate a `patchedDependencies` key's shape, rejecting only a
-/// non-`*` selector that isn't a valid semver range (pnpm's
-/// `PATCH_NON_SEMVER_RANGE`). Every other shape — exact, range, `*`,
-/// bare name — is accepted; mapping the key to concrete resolved
-/// versions is [`aube_lockfile::patch_groups`]'s job. Kept a thin
-/// wrapper so the invalid-range error carries the branded code.
+/// non-`*` selector that is neither a valid semver range nor a
+/// `<protocol>:` source identity (pnpm's `PATCH_NON_SEMVER_RANGE`).
+/// Every other shape — exact, range, `*`, bare name, and a bun-style
+/// `name@github:owner/repo#sha` — is accepted; mapping the key to
+/// concrete resolved versions is [`aube_lockfile::patch_groups`]'s job.
+/// Kept a thin wrapper so the invalid-range error carries the branded
+/// code.
 fn validate_patch_key(key: &str) -> Result<()> {
     aube_lockfile::patch_groups::classify_patch_key(key).map_err(|e| {
         miette!(
@@ -97,9 +100,12 @@ fn validate_patch_key(key: &str) -> Result<()> {
 /// keyed by the CONCRETE resolved `name@version` those stages apply
 /// patches by: a `(name@version, content)` content map and a
 /// `(name@version, content_hash)` fold map. The declared keys may be
-/// exact (`ms@2.1.3`), a range (`ms@>=2`), a wildcard (`ms@*`), or a
-/// bare name (`ms`); each graph package resolves to at most one patch
-/// by pnpm's `getPatchInfo` priority (exact > range > all). An
+/// exact (`ms@2.1.3`), a range (`ms@>=2`), a wildcard (`ms@*`), a bare
+/// name (`ms`), or a source identity (`pkg@github:owner/repo#sha`, which
+/// matches through the exact branch because that string is what the
+/// lockfile records as such a package's version); each graph package
+/// resolves to at most one patch by pnpm's `getPatchInfo` priority
+/// (exact > range > all). An
 /// all-exact project resolves each key to its own `name@version`, so
 /// the maps are byte-identical to the pre-resolution behavior.
 ///
@@ -679,15 +685,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validate_accepts_all_pnpm_key_shapes() {
+    fn validate_accepts_every_supported_key_shape() {
         // The parse-time gate now rejects ONLY a non-`*` invalid range;
-        // exact, range, `*`, and bare-name keys all pass.
+        // exact, range, `*`, and bare-name keys all pass. A bun-style
+        // source identity passes too — the last two entries are the shape
+        // that used to refuse opencode's whole install with
+        // ERR_AUBE_PATCH_NON_SEMVER_RANGE.
         for key in [
             "is-positive@3.1.0",
             "@babel/core@7.0.0",
             "sonda",
             "sonda@*",
             "sonda@>=1",
+            "ghostty-web@github:anomalyco/ghostty-web#83c0a07",
+            "pkg@file:./vendor/pkg",
         ] {
             assert!(validate_patch_key(key).is_ok(), "should accept {key:?}");
         }

--- a/vendor/aube/crates/aube/src/patches.rs
+++ b/vendor/aube/crates/aube/src/patches.rs
@@ -96,6 +96,27 @@ fn validate_patch_key(key: &str) -> Result<()> {
     Ok(())
 }
 
+/// The same gate under **pnpm's grammar only**, for a key that did not
+/// come from bun's field — the branded `pnpm.*` object and this tool's
+/// own namespace (`pnpm_patched_dependencies`), plus the workspace yaml.
+///
+/// `load_declared_patch_paths` merges all of those with bun's into one
+/// map and the origin is gone after that, so the check happens here, as
+/// each is read. Otherwise bun's source-identity key shape would
+/// silently become legal in a pnpm project, which pnpm itself refuses:
+/// `groupPatchedDependencies` runs `validRange` on the selector and
+/// throws `PATCH_NON_SEMVER_RANGE`.
+fn validate_pnpm_patch_key(key: &str) -> Result<()> {
+    aube_lockfile::patch_groups::classify_pnpm_patch_key(key).map_err(|e| {
+        miette!(
+            code = aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE,
+            "{}",
+            e.message()
+        )
+    })?;
+    Ok(())
+}
+
 /// Build the two shapes the linker + GVS-prewarm materializer want,
 /// keyed by the CONCRETE resolved `name@version` those stages apply
 /// patches by: a `(name@version, content)` content map and a
@@ -105,9 +126,9 @@ fn validate_patch_key(key: &str) -> Result<()> {
 /// matches through the exact branch because that string is what the
 /// lockfile records as such a package's version); each graph package
 /// resolves to at most one patch by pnpm's `getPatchInfo` priority
-/// (exact > range > all). An
-/// all-exact project resolves each key to its own `name@version`, so
-/// the maps are byte-identical to the pre-resolution behavior.
+/// (exact > range > all). An all-exact project resolves each key to its
+/// own `name@version`, so the maps are byte-identical to the
+/// pre-resolution behavior.
 ///
 /// Two ranges matching one version → [`aube_codes::errors::ERR_AUBE_PATCH_KEY_CONFLICT`];
 /// an invalid non-`*` range → [`aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE`].
@@ -212,12 +233,19 @@ pub(crate) fn load_declared_patch_paths(cwd: &Path) -> Result<BTreeMap<String, S
             .map_err(miette::Report::new)
             .wrap_err("failed to read package.json")?;
         entries.extend(manifest.bun_patched_dependencies());
-        entries.extend(manifest.pnpm_patched_dependencies());
+        let pnpm_declared = manifest.pnpm_patched_dependencies();
+        for key in pnpm_declared.keys() {
+            validate_pnpm_patch_key(key)?;
+        }
+        entries.extend(pnpm_declared);
     }
 
     let ws_config = aube_manifest::workspace::WorkspaceConfig::load(cwd)
         .map_err(miette::Report::new)
         .wrap_err("failed to read pnpm-workspace.yaml")?;
+    for key in ws_config.patched_dependencies.keys() {
+        validate_pnpm_patch_key(key)?;
+    }
     entries.extend(ws_config.patched_dependencies);
     Ok(entries)
 }
@@ -734,6 +762,41 @@ mod tests {
             patch_with_content("hello\r\n").content_hash(),
             patch_with_content("hello\n").content_hash(),
         );
+    }
+
+    /// Bun's source-identity key shape is bun's alone. A key read from
+    /// `pnpm.patchedDependencies` goes through the same merged map and
+    /// the same permissive classifier, so without a check at the READ
+    /// site a pnpm project would silently gain a key shape pnpm itself
+    /// refuses (`groupPatchedDependencies` runs `validRange` and throws
+    /// `PATCH_NON_SEMVER_RANGE`).
+    #[test]
+    fn a_pnpm_declared_source_identity_is_refused_where_bun_s_is_taken() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("patches")).unwrap();
+        std::fs::write(dir.path().join("patches/p.patch"), "").unwrap();
+
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"pnpm":{"patchedDependencies":{"is-positive@file:./vendor":"patches/p.patch"}}}"#,
+        )
+        .unwrap();
+        let err = load_declared_patch_paths(dir.path())
+            .expect_err("a pnpm-declared source identity must be refused");
+        assert_eq!(
+            err.code().map(|c| c.to_string()).as_deref(),
+            Some(aube_codes::errors::ERR_AUBE_PATCH_NON_SEMVER_RANGE),
+        );
+
+        // The identical key under bun's own field is accepted.
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"patchedDependencies":{"is-positive@file:./vendor":"patches/p.patch"}}"#,
+        )
+        .unwrap();
+        let entries =
+            load_declared_patch_paths(dir.path()).expect("bun's field carries bun's grammar");
+        assert!(entries.contains_key("is-positive@file:./vendor"));
     }
 
     /// pnpm's `verifyPatches` contract: a declared key that matches no


### PR DESCRIPTION
`ghostty-web@github:anomalyco/ghostty-web#83c0a07` failed with `ERR_NUB_PATCH_NON_SEMVER_RANGE`: `classify_patch_key` mirrors pnpm, which reads any non-`*` selector as a semver range.

Bun never parses these keys — it hashes the key and looks a package up under `<name>@<resolution>`. That resolution is already what `classify_bun_ident` stores as `LockedPackage.version`, so the key classifies as `Exact` and the existing lookup matches.

The branch is reached only after the range parse fails, and the gate is a protocol token, so `foo@^^1:2` still errors.

Verified on opencode: unfixed nub refuses, fixed nub links a patched `ghostty-web`.