### PR TITLE
agent: show concise docs help and table of contents

### DIFF
--- a/crates/nub-cli/src/agent/mod.rs
+++ b/crates/nub-cli/src/agent/mod.rs
@@ -70,7 +70,7 @@ pub fn run(args: &[String]) -> Result<i32> {
     }
 }
 
-/// `nub agent docs [--page <path> | --list]`.
+/// `nub agent docs [--page <path> | --list | --toc]`.
 ///
 /// No args → usage and the page TOC, without any page's markdown.
 /// `--list` / `--toc` → just the TOC.
@@ -98,7 +98,7 @@ fn run_docs(args: &[String]) -> Result<i32> {
             }
             other => bail!(
                 "nub agent docs: unexpected argument '{other}'. \
-                 Usage: nub agent docs [--page <path> | --list]."
+                 Usage: nub agent docs [--page <path> | --list | --toc]."
             ),
         }
     }
@@ -114,7 +114,7 @@ fn run_docs(args: &[String]) -> Result<i32> {
 
     println!(
         "nub agent docs — browse the bundled docs offline\n\n\
-         Usage: nub agent docs [--page <path> | --list]\n\n\
+         Usage: nub agent docs [--page <path> | --list | --toc]\n\n\
          Options:\n\
          \x20 --page <path>  Print one page's full markdown\n\
          \x20 --list, --toc  Print only the table of contents\n\
@@ -186,7 +186,7 @@ fn print_usage() {
          \x20 docs     show docs usage and a table of contents\n\
          \x20          (offline fallback for https://nubjs.com/docs)\n\
          \x20          --page <path>  print one page's full markdown (e.g. /docs/runtime/jsx)\n\
-         \x20          --list         print just the page TOC\n\
+         \x20          --list, --toc  print just the page TOC\n\
          \x20 skill    print nub's evergreen agent skill to stdout (install it yourself)"
     );
 }
@@ -403,8 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn docs_no_args_mirrors_toc_then_index() {
-        // No args is the mirror: TOC at top + the /docs index content + fetch note.
+    fn docs_help_and_list_variants_succeed() {
         assert_eq!(run_docs(&[]).unwrap(), 0);
         // `--list`/`--toc` is the TOC-only variant.
         assert_eq!(run_docs(&["--list".into()]).unwrap(), 0);

--- a/crates/nub-cli/src/agent/mod.rs
+++ b/crates/nub-cli/src/agent/mod.rs
@@ -6,10 +6,8 @@
 //! user pastes into their own coding agent; these verbs are the OFFLINE FALLBACK
 //! for when that agent can't fetch the live docs over the web:
 //!
-//! - `docs`  — MIRRORS the published docs. With no args it prints the page TOC
-//!   at the top, then the `/docs` index page's markdown (the same content served
-//!   at https://nubjs.com/docs), then a one-line note that every slug — and every
-//!   markdown link target inside the pages — is a valid `--page` argument. The
+//! - `docs` — prints usage and the page TOC. Full markdown is opt-in through
+//!   `--page`; every slug and markdown link target is a valid argument. The
 //!   slugs ARE the in-doc link hrefs (`/docs/runtime/decorators`, …), so an agent
 //!   can take a markdown link target and plug it straight into `--page`. `--page
 //!   <path>` prints one page's full markdown; `--list`/`--toc` prints just the
@@ -46,7 +44,7 @@ mod baked {
 use baked::DOCS;
 
 /// The canonical slug for the docs index page (`site/content/docs/index.mdx`,
-/// served at `/docs`). Its body is printed verbatim by the no-args invocation.
+/// served at `/docs`).
 const INDEX_SLUG: &str = "/docs";
 
 /// Entry point for `nub agent …`, dispatched from `dispatch_subcommand`.
@@ -74,9 +72,7 @@ pub fn run(args: &[String]) -> Result<i32> {
 
 /// `nub agent docs [--page <path> | --list]`.
 ///
-/// No args  → MIRRORS the docs: the page TOC at the top, then the `/docs` index
-///            page's markdown, then a note that every slug (and every in-doc
-///            link target) is a valid `--page` argument.
+/// No args → usage and the page TOC, without any page's markdown.
 /// `--list` / `--toc` → just the TOC.
 /// `--page <path>` → that page's full markdown (frontmatter stripped). The path
 ///            is the page's `/docs/...` URL — the same form the docs link to — so
@@ -116,16 +112,17 @@ fn run_docs(args: &[String]) -> Result<i32> {
         return Ok(0);
     }
 
-    // Mirror the docs: TOC first, then the /docs index page, then fetch note.
-    print_toc();
-    println!();
-    if let Some((_, _, body)) = DOCS.iter().find(|(s, _, _)| *s == INDEX_SLUG) {
-        print!("{body}");
-        println!();
-    }
     println!(
-        "---\n\nFetch a page's full markdown, e.g.:\n\n    nub agent docs --page /docs/runtime/decorators"
+        "nub agent docs — browse the bundled docs offline\n\n\
+         Usage: nub agent docs [--page <path> | --list]\n\n\
+         Options:\n\
+         \x20 --page <path>  Print one page's full markdown\n\
+         \x20 --list, --toc  Print only the table of contents\n\
+         \x20 -h, --help     Show agent command help\n\n\
+         Example:\n\
+         \x20 nub agent docs --page /docs/runtime/decorators\n"
     );
+    print_toc();
     Ok(0)
 }
 
@@ -175,7 +172,7 @@ fn print_page(slug: &str) -> Result<i32> {
 /// is the page's `/docs/...` URL path — the same href the docs link to — so it
 /// doubles as a `--page` argument.
 fn print_toc() {
-    println!("## Docs pages — pass any path to `nub agent docs --page <path>`\n");
+    println!("Table of contents:");
     for (slug, title, _) in DOCS {
         println!("  {slug} — {title}");
     }
@@ -186,7 +183,7 @@ fn print_usage() {
         "nub agent — make AI coding agents reach for nub\n\n\
          Usage: nub agent <command>\n\n\
          Commands:\n\
-         \x20 docs     mirror the docs: a TOC of every page + the /docs index content\n\
+         \x20 docs     show docs usage and a table of contents\n\
          \x20          (offline fallback for https://nubjs.com/docs)\n\
          \x20          --page <path>  print one page's full markdown (e.g. /docs/runtime/jsx)\n\
          \x20          --list         print just the page TOC\n\
@@ -205,11 +202,10 @@ mod tests {
     }
 
     #[test]
-    fn docs_verb_mirrors_the_docs_and_drops_start_md() {
-        // `nub agent docs` mirrors the docs and exits 0.
+    fn docs_verb_lists_the_baked_docs() {
         assert_eq!(run(&["docs".into()]).unwrap(), 0);
 
-        // The /docs index page is baked and non-empty — it's what no-args prints.
+        // The overview remains available through --page /docs.
         let index = DOCS
             .iter()
             .find(|(s, _, _)| *s == INDEX_SLUG)
@@ -219,9 +215,6 @@ mod tests {
             "index body must be the real /docs page content"
         );
 
-        // start.md is GONE: the embedded onboarding-doc const no longer exists.
-        // (Asserted structurally — the `START_MD` symbol was removed; if it were
-        // reintroduced this module wouldn't compile against the old reference.)
         let toc_out = DOCS.iter().map(|(s, _, _)| *s).collect::<Vec<_>>();
         assert!(
             toc_out.contains(&INDEX_SLUG),

--- a/crates/nub-cli/tests/agent_docs.rs
+++ b/crates/nub-cli/tests/agent_docs.rs
@@ -1,0 +1,72 @@
+use std::process::{Command, Output};
+
+fn docs(args: &[&str]) -> Output {
+    let dir = tempfile::tempdir().unwrap();
+    Command::new(env!("CARGO_BIN_EXE_nub"))
+        .args(["agent", "docs"])
+        .args(args)
+        .current_dir(dir.path())
+        .output()
+        .expect("run nub agent docs")
+}
+
+fn stdout(args: &[&str]) -> String {
+    let output = docs(args);
+    assert!(output.status.success(), "{output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn default_output_is_help_and_toc_without_page_content() {
+    let output = stdout(&[]);
+    assert!(output.starts_with("nub agent docs —"));
+    for heading in ["Usage:", "Options:", "Example:", "Table of contents:"] {
+        assert!(output.contains(heading), "missing {heading}: {output}");
+    }
+    let list = stdout(&["--list"]);
+    let (help, toc) = output.split_once("Table of contents:").unwrap();
+    assert_eq!(format!("Table of contents:{toc}"), list);
+    assert!(help.lines().count() <= 14, "help should remain concise");
+    assert!(!output.contains("all-in-one toolkit"));
+    assert!(!output.contains("```"));
+}
+
+#[test]
+fn list_aliases_print_only_page_paths_and_titles() {
+    let list = stdout(&["--list"]);
+    assert_eq!(list, stdout(&["--toc"]));
+    assert_eq!(list.lines().next(), Some("Table of contents:"));
+    assert!(list.contains("  /docs — Introduction"));
+    for line in list.lines().skip(1) {
+        assert!(line.starts_with("  /docs"), "unexpected content: {line}");
+        assert!(line.contains(" — "), "missing page title: {line}");
+    }
+}
+
+#[test]
+fn explicit_pages_still_print_markdown_and_accept_link_targets() {
+    let overview = stdout(&["--page", "/docs"]);
+    assert!(overview.contains("all-in-one toolkit"));
+    assert!(overview.contains("```bash"));
+    for alias in ["/", "docs", "/docs#install"] {
+        assert_eq!(overview, stdout(&["--page", alias]));
+    }
+    assert_eq!(overview, stdout(&["--page=/docs"]));
+    let page = stdout(&["--page", "/docs/run"]);
+    assert_eq!(page, stdout(&["--page", "run"]));
+    assert!(!page.starts_with("nub agent docs —"));
+}
+
+#[test]
+fn help_and_invalid_arguments_keep_their_exit_statuses() {
+    for flag in ["--help", "-h"] {
+        assert!(stdout(&[flag]).contains("Usage: nub agent <command>"));
+    }
+    for args in [vec!["--page"], vec!["--page", "/missing"], vec!["--bogus"]] {
+        let output = docs(&args);
+        assert!(!output.status.success(), "{args:?}: {output:?}");
+        assert!(output.stdout.is_empty(), "{output:?}");
+        assert!(!output.stderr.is_empty(), "{output:?}");
+    }
+}

--- a/site/content/docs/index.mdx
+++ b/site/content/docs/index.mdx
@@ -120,3 +120,13 @@ Unknown keys and invalid values stop the command with an error. See [nub.jsonc](
 ## Next steps
 
 - Quick answers: the [FAQ](/docs/faq).
+
+### Offline docs
+
+Nub bundles the documentation for offline access. The default command prints usage and a table of contents; select a page to read its Markdown.
+
+```sh
+nub agent docs
+nub agent docs --page /docs/run
+nub agent docs --list            # only the table of contents
+```

--- a/site/public/start.md
+++ b/site/public/start.md
@@ -81,7 +81,7 @@ Two facts to hold onto when proposing changes:
 Nub ships its full docs offline:
 
 ```sh
-nub agent docs                   # table of contents + the overview page
+nub agent docs                   # usage + table of contents
 nub agent docs --page /docs/run  # any page's full markdown
 nub agent docs --list            # just the page list
 ```


### PR DESCRIPTION
Print usage, options, an example, and the docs table of contents instead of appending the overview Markdown. Full pages remain available through `--page`.

Updated the offline-docs guidance and added CLI regression tests for output, aliases, page selection, help, and errors.

Verified on a remote Linux builder: focused agent tests, all bundled pages and their aliases, and `cargo clippy --all-targets --all-features -- -D warnings`. Formatting and the site build passed. Full PR CI not requested under the small-change policy.