### PR TITLE
Serve a default-exported fetch handler

### DIFF
--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4718,6 +4718,18 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
         );
     }
 
+    // Default-export `fetch` handler: let the preload's deferred pass serve an entry
+    // whose default export is one. A plain `nub <file>` only — a bin launch
+    // (`exec_ua`) is running somebody else's tool, and the `node` hijack has to keep
+    // `node <file>` meaning what `node` means, so a script's `node server.js` never
+    // binds a port while `nub server.js` does. See `flags::SERVE_ENTRY_ENV`.
+    if !compat_mode && !exec_ua && !NODE_HIJACK.load(Ordering::Relaxed) {
+        env_vars.insert(
+            nub_core::node::flags::SERVE_ENTRY_ENV.to_string(),
+            "1".to_string(),
+        );
+    }
+
     // Dep-check dedup across processes (#252): once this process owns the
     // decision, mark the spawned child so a hijack-descendant `node` (a worker a
     // test runner forks) skips re-checking and the warning appears at most once.
@@ -7322,6 +7334,14 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit());
     cmd.env(crate::project_config::RUNTIME_CONFIG_ENV, runtime_json);
+    // Default-export `fetch` handler, same signal the direct-spawn path sets. Node's
+    // watch supervisor re-execs the child with this environment, so a restart rebinds
+    // the listener — which is the whole point of watching a server. `nub watch` has no
+    // `--node` form to exclude (it refuses compat outright), so the resolved
+    // `nodeCompat` from the project config is the only opt-out to honor.
+    if !compat_mode {
+        cmd.env(nub_core::node::flags::SERVE_ENTRY_ENV, "1");
+    }
     // Tell the preload to hide nub's argv-only V8 flags from `process.execArgv`, the same
     // signal the direct-spawn path sets. Node's watch supervisor re-execs the child with
     // this environment, so it survives every restart.

--- a/crates/nub-cli/src/cli.rs
+++ b/crates/nub-cli/src/cli.rs
@@ -4722,11 +4722,13 @@ fn run_file_in_dir(args: &[String], compat_mode: bool, cwd: &Path, exec_ua: bool
     // whose default export is one. A plain `nub <file>` only — a bin launch
     // (`exec_ua`) is running somebody else's tool, and the `node` hijack has to keep
     // `node <file>` meaning what `node` means, so a script's `node server.js` never
-    // binds a port while `nub server.js` does. See `flags::SERVE_ENTRY_ENV`.
+    // binds a port while `nub server.js` does. Carries the argv rather than a flag so
+    // the preload can tell the application from a wrapper nub puts in front of it —
+    // see `flags::SERVE_ENTRY_ENV`.
     if !compat_mode && !exec_ua && !NODE_HIJACK.load(Ordering::Relaxed) {
         env_vars.insert(
             nub_core::node::flags::SERVE_ENTRY_ENV.to_string(),
-            "1".to_string(),
+            nub_core::node::flags::serve_entry_marker(args.iter().map(String::as_str)),
         );
     }
 
@@ -7340,7 +7342,12 @@ fn run_watch(file: &str, args: &[String]) -> Result<i32> {
     // `--node` form to exclude (it refuses compat outright), so the resolved
     // `nodeCompat` from the project config is the only opt-out to honor.
     if !compat_mode {
-        cmd.env(nub_core::node::flags::SERVE_ENTRY_ENV, "1");
+        cmd.env(
+            nub_core::node::flags::SERVE_ENTRY_ENV,
+            nub_core::node::flags::serve_entry_marker(
+                std::iter::once(file).chain(args.iter().map(String::as_str)),
+            ),
+        );
     }
     // Tell the preload to hide nub's argv-only V8 flags from `process.execArgv`, the same
     // signal the direct-spawn path sets. Node's watch supervisor re-execs the child with

--- a/crates/nub-cli/src/compile/bundle.rs
+++ b/crates/nub-cli/src/compile/bundle.rs
@@ -2536,7 +2536,7 @@ impl CompilePreamble {
 
     fn root_source(&self, id: &str) -> Option<String> {
         let source = self.roots.lock().ok()?.get(id)?.clone();
-        Some(compile_root_source(&source))
+        Some(compile_root_source(&source, id == COMPILE_ROOT_ID))
     }
 
     fn has_root(&self, id: &str) -> bool {
@@ -2551,10 +2551,6 @@ impl CompilePreamble {
     }
 }
 
-/// The only code generated for a root.  Both imports are static and
-/// side-effectful: prelude first, program second.  JSON quoting keeps Windows
-/// separators and every filename character out of JavaScript grammar concerns;
-/// Rolldown resolves the absolute id only while building and never emits it.
 /// Drop a Windows verbatim (`\\?\`) prefix. Pure over `windows` so both branches
 /// test on any host.
 pub fn strip_verbatim_prefix(path: PathBuf, windows: bool) -> PathBuf {
@@ -2586,11 +2582,30 @@ fn canonicalize_for_bundler(path: &Path) -> PathBuf {
     strip_verbatim_prefix(canonical, cfg!(windows))
 }
 
-fn compile_root_source(source: &Path) -> String {
+/// The only code generated for a root.  Both imports are static and
+/// side-effectful: prelude first, program second.  JSON quoting keeps Windows
+/// separators and every filename character out of JavaScript grammar concerns;
+/// Rolldown resolves the absolute id only while building and never emits it.
+///
+/// The PROGRAM root also hands the entry's namespace to the prelude once the entry
+/// has evaluated — top-level await included, which a namespace import waits for —
+/// so a default-exported `fetch` handler is served exactly as `nub <file>` serves
+/// it (`serveCompiledEntry`, compile-preamble.mjs). A worker root never does:
+/// under `nub <file>` a Worker copies its environment after the serve marker is
+/// gone, and an artifact keeps that. A CommonJS root needs nothing further, since
+/// Rolldown's interop hands `module.exports` over as `default`, the shape the
+/// handler check already unwraps.
+fn compile_root_source(source: &Path, program: bool) -> String {
     let prelude = serde_json::to_string(COMPILE_PREAMBLE_ID).expect("a virtual id serializes");
     let source =
         serde_json::to_string(&source.to_string_lossy()).expect("a source path serializes");
-    format!("import {prelude};\nimport {source};\n")
+    if program {
+        format!(
+            "import {{ serveCompiledEntry }} from {prelude};\nimport * as entry from {source};\nserveCompiledEntry(entry);\n"
+        )
+    } else {
+        format!("import {prelude};\nimport {source};\n")
+    }
 }
 
 /// Locate exactly the public runtime whose dependencies compiled artifacts need.
@@ -7904,14 +7919,25 @@ mod tests {
     #[test]
     fn compile_root_statically_imports_the_prelude_before_the_program() {
         let source = Path::new("/tmp/compile prelude/main.cjs");
-        let wrapper = compile_root_source(source);
         let prelude = serde_json::to_string(COMPILE_PREAMBLE_ID).unwrap();
         let program = serde_json::to_string(&source.to_string_lossy()).unwrap();
-        assert_eq!(wrapper, format!("import {prelude};\nimport {program};\n"));
-        assert!(
-            wrapper.find(&prelude).unwrap() < wrapper.find(&program).unwrap(),
-            "the side-effect prelude must be evaluated before authored code: {wrapper}"
+        let worker = compile_root_source(source, false);
+        assert_eq!(worker, format!("import {prelude};\nimport {program};\n"));
+        // The program root hands the evaluated entry to the prelude; a worker root
+        // never serves, so it stays the two bare imports.
+        let wrapper = compile_root_source(source, true);
+        assert_eq!(
+            wrapper,
+            format!(
+                "import {{ serveCompiledEntry }} from {prelude};\nimport * as entry from {program};\nserveCompiledEntry(entry);\n"
+            )
         );
+        for wrapper in [&worker, &wrapper] {
+            assert!(
+                wrapper.find(&prelude).unwrap() < wrapper.find(&program).unwrap(),
+                "the side-effect prelude must be evaluated before authored code: {wrapper}"
+            );
+        }
     }
 
     #[test]
@@ -9169,12 +9195,12 @@ mod tests {
         let roots = CompilePreamble::from_source(program, PathBuf::new(), String::new());
         let worker_id = roots.worker_root(worker).unwrap();
         assert_ne!(worker_id, COMPILE_ROOT_ID);
-        let program_wrapper = compile_root_source(program);
+        let program_wrapper = compile_root_source(program, true);
         assert_eq!(
             roots.root_source(COMPILE_ROOT_ID).as_deref(),
             Some(program_wrapper.as_str())
         );
-        let worker_wrapper = compile_root_source(worker);
+        let worker_wrapper = compile_root_source(worker, false);
         assert_eq!(
             roots.root_source(&worker_id).as_deref(),
             Some(worker_wrapper.as_str())
@@ -9734,7 +9760,7 @@ console.log('ESM_ENTRY_MARK', path.sep);
     #[test]
     fn dynamic_global_access_still_has_an_unconditional_prelude_import() {
         let source = Path::new("/tmp/nub-prelude/dynamic-global.ts");
-        let wrapper = compile_root_source(source);
+        let wrapper = compile_root_source(source, true);
         assert!(
             wrapper.starts_with("import "),
             "the wrapper must not depend on a statically named global that the prelude creates: {wrapper}"

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -18,6 +18,13 @@
 //! runs a fixture that another test proves does get served, so a green absence means
 //! the exclusion held rather than that the feature was never wired. Measured with the
 //! installer stubbed out: fifteen of these go red, and exactly those three stay green.
+//!
+//! One invariant this file deliberately does NOT test: that the detection pass never
+//! evaluates the entry ahead of the user's preloads. It cannot be tested here, because
+//! the ordering only becomes racy on the tier where nub's preload is itself an
+//! `--import`, so a single-Node run passes structurally whatever the code does.
+//! `version_tiers::cjs_preload_runs_once_after_hooks_on_both_tiers` is the guard —
+//! it runs the tier matrix, and it is what caught the regression.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -12,6 +12,12 @@
 //!
 //! The mechanism is tier-independent (both preload entries call the same installer),
 //! so the host Node covers whichever tier it falls on.
+//!
+//! Three tests here assert that something is NOT served, and an absence assertion
+//! cannot fail on its own. Their positive control is the rest of this file: each one
+//! runs a fixture that another test proves does get served, so a green absence means
+//! the exclusion held rather than that the feature was never wired. Measured with the
+//! installer stubbed out: fifteen of these go red, and exactly those three stay green.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -78,22 +84,29 @@ fn start(name: &str, env: &[(&str, &str)]) -> Server {
     // that reads one to EOF hangs instead of failing.
     let stdout = drain(child.stdout.take().unwrap());
     let stderr = drain(child.stderr.take().unwrap());
+    // Built before the wait below, so `Drop` owns the process from here on. A startup
+    // timeout panics, and without that ownership the panic would abandon a server still
+    // holding its port.
+    let mut server = Server {
+        child,
+        host: String::new(),
+        port: 0,
+        startup_line: String::new(),
+        stdout,
+        stderr,
+    };
     let mut seen = Vec::new();
     loop {
-        let line = stderr.recv_timeout(STARTUP_TIMEOUT).unwrap_or_else(|_| {
+        let line = server.stderr.recv_timeout(STARTUP_TIMEOUT).unwrap_or_else(|_| {
             panic!(
                 "{name}: no `Listening on` line within {STARTUP_TIMEOUT:?}; stderr so far: {seen:?}"
             )
         });
         if let Some((host, port)) = listening_address(&line) {
-            return Server {
-                child,
-                host,
-                port,
-                startup_line: line,
-                stdout,
-                stderr,
-            };
+            server.host = host;
+            server.port = port;
+            server.startup_line = line;
+            return server;
         }
         seen.push(line);
     }
@@ -239,10 +252,7 @@ fn parse(raw: &[u8]) -> Reply {
 /// form has to be decoded before the body can be compared.
 fn dechunk(mut rest: &[u8]) -> String {
     let mut out = Vec::new();
-    loop {
-        let Some(eol) = rest.windows(2).position(|w| w == b"\r\n") else {
-            break;
-        };
+    while let Some(eol) = rest.windows(2).position(|w| w == b"\r\n") {
         let size_line = String::from_utf8_lossy(&rest[..eol]).into_owned();
         let size = usize::from_str_radix(size_line.split(';').next().unwrap().trim(), 16)
             .unwrap_or_else(|_| panic!("bad chunk size {size_line:?}"));

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -17,7 +17,7 @@
 //! cannot fail on its own. Their positive control is the rest of this file: each one
 //! runs a fixture that another test proves does get served, so a green absence means
 //! the exclusion held rather than that the feature was never wired. Measured with the
-//! installer stubbed out: seventeen of these go red, and exactly those three stay green.
+//! installer stubbed out: nineteen of these go red, and exactly those three stay green.
 //!
 //! One invariant this file deliberately does NOT test: that the detection pass never
 //! evaluates the entry ahead of the user's preloads. It cannot be tested here, because
@@ -614,6 +614,24 @@ fn a_watched_handler_behind_an_env_owner_loader_is_served() {
         &["watch", "server.mjs"],
         &[],
         "behind the loader, watched",
+    );
+    assert_eq!(get(&s, "/").body, "FROM_LOADER=yes");
+    drop(s);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Only the entry identifies the application. An argument that happens to name the
+/// loader's own bin is just an argument: the loader — whose `argv[1]` IS that bin —
+/// must leave the signal for the application rather than claim it on that match.
+#[cfg(unix)]
+#[test]
+fn an_argument_naming_the_wrapper_does_not_consume_the_signal() {
+    let dir = wrapped_project("argv");
+    let s = launch(
+        &dir,
+        &["server.mjs", "node_modules/.bin/varlock"],
+        &[],
+        "behind the loader, naming it",
     );
     assert_eq!(get(&s, "/").body, "FROM_LOADER=yes");
     drop(s);

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -316,6 +316,36 @@ fn top_level_await_settles_before_detection() {
     assert_eq!(get(&s, "/").body, "ready after await");
 }
 
+/// A preload on its own `--import` token may still be pending when the detection
+/// pass first runs, so the entry cannot be imported then; and a preload that holds a
+/// timer keeps the loop from ever draining, so waiting for idleness would never
+/// serve. The listener binds anyway, on the load hook's word that Node has started
+/// the entry — for an ES module entry, for a CommonJS one the ESM loader owns once an
+/// `--import` is present, and when it is the entry's own body holding the loop.
+#[test]
+fn a_foreign_preload_holding_the_loop_does_not_block_binding() {
+    let holds_loop = "data:text/javascript,setInterval(()=>{},1000);";
+    let quiet = "data:text/javascript,globalThis.quiet=1;";
+    for (preload, name, body) in [
+        (holds_loop, "server.mjs", "hello from /?"),
+        (holds_loop, "server.cjs", "hello from commonjs"),
+        (quiet, "holds-loop.mjs", "holds the loop"),
+    ] {
+        let f = fixture(name);
+        let s = launch(
+            f.parent().unwrap(),
+            &["--import", preload, f.to_str().unwrap()],
+            &[],
+            name,
+        );
+        assert_eq!(
+            get(&s, "/").body,
+            body,
+            "{name} behind `--import {preload}`"
+        );
+    }
+}
+
 // ── The request and response bridge ──────────────────────────────────
 
 /// Method, headers and a request body reach the handler, and the handler's status,

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -17,7 +17,7 @@
 //! cannot fail on its own. Their positive control is the rest of this file: each one
 //! runs a fixture that another test proves does get served, so a green absence means
 //! the exclusion held rather than that the feature was never wired. Measured with the
-//! installer stubbed out: fifteen of these go red, and exactly those three stay green.
+//! installer stubbed out: seventeen of these go red, and exactly those three stay green.
 //!
 //! One invariant this file deliberately does NOT test: that the detection pass never
 //! evaluates the entry ahead of the user's preloads. It cannot be tested here, because
@@ -76,9 +76,14 @@ impl Drop for Server {
 
 fn start(name: &str, env: &[(&str, &str)]) -> Server {
     let f = fixture(name);
+    launch(f.parent().unwrap(), &[f.to_str().unwrap()], env, name)
+}
+
+/// `nub <args…>` in `dir`, waited for until it reports its listener.
+fn launch(dir: &Path, args: &[&str], env: &[(&str, &str)], name: &str) -> Server {
     let mut cmd = Command::new(nub_binary());
-    cmd.arg(&f)
-        .current_dir(f.parent().unwrap())
+    cmd.args(args)
+        .current_dir(dir)
         .env("PORT", "0")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -511,6 +516,78 @@ fn the_node_hijack_does_not_serve() {
         !stderr.contains("Listening on"),
         "`node <file>` must not bind a listener: {stderr:?}"
     );
+}
+
+// ── Behind a wrapper ────────────────────────────────────────────────
+
+/// A project whose environment an external loader owns: a `.env.schema` beside a
+/// `#!/usr/bin/env node` loader in `node_modules/.bin`, which is the shape `varlock`
+/// ships. Nub spawns the loader in FRONT of Node, and the loader — itself a Node
+/// process, running nub's inherited preload — copies its environment into the
+/// application. The handler echoes the variable the loader adds, so a matching
+/// response proves it was served from a process launched THROUGH the loader rather
+/// than from one nub spawned directly.
+#[cfg(unix)]
+fn wrapped_project(tag: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!("nub-fetch-wrapped-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let bin = dir.join("node_modules/.bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{ "name": "wrapped", "version": "1.0.0", "type": "module" }"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join(".env.schema"), "# ---\nA=1\n").unwrap();
+    std::fs::write(
+        dir.join("server.mjs"),
+        "export default {\n  fetch() {\n    return new Response(`FROM_LOADER=${process.env.FROM_LOADER ?? \"<unset>\"}`);\n  },\n};\n",
+    )
+    .unwrap();
+    let loader = bin.join("varlock");
+    std::fs::write(
+        &loader,
+        "#!/usr/bin/env node\n\
+         const { spawnSync } = require(\"node:child_process\");\n\
+         const argv = process.argv.slice(2);\n\
+         const cmd = argv.slice(argv.indexOf(\"--\") + 1);\n\
+         const res = spawnSync(cmd[0], cmd.slice(1), { stdio: \"inherit\", env: { ...process.env, FROM_LOADER: \"yes\" } });\n\
+         process.exit(res.status ?? 1);\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&loader, std::fs::Permissions::from_mode(0o755)).unwrap();
+    dir
+}
+
+/// The serve signal names the application, not whatever process nub spawns. The
+/// loader in front of Node runs nub's preload too, and a signal it consumed there
+/// never reached the application, which then ran as a plain script.
+#[cfg(unix)]
+#[test]
+fn a_handler_behind_an_env_owner_loader_is_served() {
+    let dir = wrapped_project("run");
+    let s = launch(&dir, &["server.mjs"], &[], "behind the loader");
+    assert_eq!(get(&s, "/").body, "FROM_LOADER=yes");
+    drop(s);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Same through `nub watch`, whose supervisor re-execs the child with the signal in
+/// its environment and the loader still in front.
+#[cfg(unix)]
+#[test]
+fn a_watched_handler_behind_an_env_owner_loader_is_served() {
+    let dir = wrapped_project("watch");
+    let s = launch(
+        &dir,
+        &["watch", "server.mjs"],
+        &[],
+        "behind the loader, watched",
+    );
+    assert_eq!(get(&s, "/").body, "FROM_LOADER=yes");
+    drop(s);
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ── Address selection ───────────────────────────────────────────────

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -620,22 +620,29 @@ fn a_watched_handler_behind_an_env_owner_loader_is_served() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
-/// Only the entry identifies the application. An argument that happens to name the
-/// loader's own bin is just an argument: the loader — whose `argv[1]` IS that bin —
-/// must leave the signal for the application rather than claim it on that match.
+/// Only the entry identifies the application, and an application argument is just
+/// an argument, whatever it holds. One that names the loader's own bin must not let
+/// the loader — whose `argv[1]` IS that bin — claim the signal on that match; and
+/// one carrying a control byte must not split the signal's record of the argv, which
+/// once put the entry at the wrong position and served nothing.
 #[cfg(unix)]
 #[test]
-fn an_argument_naming_the_wrapper_does_not_consume_the_signal() {
-    let dir = wrapped_project("argv");
-    let s = launch(
-        &dir,
-        &["server.mjs", "node_modules/.bin/varlock"],
-        &[],
-        "behind the loader, naming it",
-    );
-    assert_eq!(get(&s, "/").body, "FROM_LOADER=yes");
-    drop(s);
-    let _ = std::fs::remove_dir_all(&dir);
+fn an_application_argument_cannot_disturb_the_claim() {
+    for (tag, args) in [
+        ("argv", &["server.mjs", "node_modules/.bin/varlock"][..]),
+        ("bytes", &["server.mjs", "a\x1fb", "--", "c"][..]),
+    ] {
+        let dir = wrapped_project(tag);
+        let s = launch(
+            &dir,
+            args,
+            &[],
+            &format!("behind the loader, args {args:?}"),
+        );
+        assert_eq!(get(&s, "/").body, "FROM_LOADER=yes", "args {args:?}");
+        drop(s);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }
 
 // ── Address selection ───────────────────────────────────────────────

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -17,7 +17,7 @@
 //! cannot fail on its own. Their positive control is the rest of this file: each one
 //! runs a fixture that another test proves does get served, so a green absence means
 //! the exclusion held rather than that the feature was never wired. Measured with the
-//! installer stubbed out: nineteen of these go red, and exactly those three stay green.
+//! installer stubbed out: twenty of these go red, and exactly those three stay green.
 //!
 //! One invariant this file deliberately does NOT test: that the detection pass never
 //! evaluates the entry ahead of the user's preloads. It cannot be tested here, because
@@ -344,6 +344,39 @@ fn a_foreign_preload_holding_the_loop_does_not_block_binding() {
             "{name} behind `--import {preload}`"
         );
     }
+}
+
+/// A preload that imports the entry ahead of the program under a query of its own is
+/// a second module, and a foreign hook may give Node's own import of the entry a
+/// query too. Only the load Node makes after resolving the entry as its main — with
+/// no parent — is the entry's; matched on pathname alone, the preload's copy was
+/// served in its place. `version_tiers` runs the same shape on the loader-worker
+/// tiers.
+#[test]
+fn a_preload_import_of_the_entry_is_not_served_in_its_place() {
+    let dir = fixture("../entry-url-rewrite");
+    let s = launch(
+        &dir,
+        &[
+            "--import",
+            "./rewrite.mjs",
+            "--import",
+            "./warm.mjs",
+            "holds.mjs",
+        ],
+        &[],
+        "entry beside a preload's copy of it",
+    );
+    assert_eq!(get(&s, "/").body, "held:?v=1");
+    let mut lines = Vec::new();
+    while let Ok(line) = s.stdout.recv_timeout(Duration::from_millis(500)) {
+        lines.push(line);
+    }
+    assert_eq!(
+        lines,
+        ["holds:?warm", "holds:?v=1"],
+        "the preload's copy first, the entry once"
+    );
 }
 
 // ── The request and response bridge ──────────────────────────────────

--- a/crates/nub-cli/tests/fetch_handler.rs
+++ b/crates/nub-cli/tests/fetch_handler.rs
@@ -1,0 +1,580 @@
+//! The default-export `fetch` handler: `nub <file>` serves an entry whose default
+//! export is an object with a `fetch` method, over the cross-runtime contract
+//! Cloudflare Workers, Bun, Deno and Vercel share.
+//!
+//! Every served fixture is launched with `PORT=0`, so the kernel picks a free port and
+//! the test reads the chosen one off the `Listening on …` line. Nothing here binds a
+//! fixed port, which is what lets these run beside each other and beside the rest of
+//! the suite. Requests go over a raw socket rather than a client crate: the contract
+//! being asserted is bytes on the wire — a repeated `Set-Cookie`, a chunked body, an
+//! absent body on a 204 — and a client that normalizes those away would hide exactly
+//! the defects this file exists to catch.
+//!
+//! The mechanism is tier-independent (both preload entries call the same installer),
+//! so the host Node covers whichever tier it falls on.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Generous on purpose: this box routinely runs a build fleet, and a starved host is
+/// not a defect in the feature.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn nub_binary() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // deps/
+    path.pop(); // debug/ or release/
+    path.push("nub");
+    path
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    Path::new(&manifest)
+        .join("../../tests/fixtures/fetch-handler")
+        .join(name)
+}
+
+/// A running server, killed when the test drops it — including when an assertion
+/// panics, which is what keeps a failure from leaking a listener into the next run.
+struct Server {
+    child: Child,
+    /// The host the server reported, which is the one to connect to: `listen(port,
+    /// "localhost")` binds whatever `localhost` resolves to, and on an IPv6 host that
+    /// is `::1`, where a hardcoded `127.0.0.1` is refused.
+    host: String,
+    port: u16,
+    /// The `Listening on …` line verbatim, which is where the chosen host shows up.
+    startup_line: String,
+    stdout: mpsc::Receiver<String>,
+    stderr: mpsc::Receiver<String>,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn start(name: &str, env: &[(&str, &str)]) -> Server {
+    let f = fixture(name);
+    let mut cmd = Command::new(nub_binary());
+    cmd.arg(&f)
+        .current_dir(f.parent().unwrap())
+        .env("PORT", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("failed to spawn nub");
+    // Both pipes drain through a thread: a live server never closes either, so anything
+    // that reads one to EOF hangs instead of failing.
+    let stdout = drain(child.stdout.take().unwrap());
+    let stderr = drain(child.stderr.take().unwrap());
+    let mut seen = Vec::new();
+    loop {
+        let line = stderr.recv_timeout(STARTUP_TIMEOUT).unwrap_or_else(|_| {
+            panic!(
+                "{name}: no `Listening on` line within {STARTUP_TIMEOUT:?}; stderr so far: {seen:?}"
+            )
+        });
+        if let Some((host, port)) = listening_address(&line) {
+            return Server {
+                child,
+                host,
+                port,
+                startup_line: line,
+                stdout,
+                stderr,
+            };
+        }
+        seen.push(line);
+    }
+}
+
+fn drain<R: std::io::Read + Send + 'static>(pipe: R) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(pipe).lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+    rx
+}
+
+/// The host and port out of `Listening on http://<host>:<port>`, with an IPv6 literal's
+/// brackets stripped so the result is what `TcpStream::connect` wants.
+fn listening_address(line: &str) -> Option<(String, u16)> {
+    let authority = line.strip_prefix("Listening on http://")?;
+    let (host, port) = authority.rsplit_once(':')?;
+    let port = port.trim().parse().ok()?;
+    Some((
+        host.trim_matches(|c| c == '[' || c == ']').to_string(),
+        port,
+    ))
+}
+
+/// Run a fixture to completion and hand back `(stdout, stderr, exit code)`.
+fn run_to_completion(name: &str, args: &[&str], env: &[(&str, &str)]) -> (String, String, i32) {
+    let f = fixture(name);
+    let mut cmd = Command::new(nub_binary());
+    cmd.args(args)
+        .arg(&f)
+        .current_dir(f.parent().unwrap())
+        .stdin(Stdio::null());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("failed to spawn nub");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+struct Reply {
+    status: u16,
+    reason: String,
+    /// Lowercased names, in the order the server sent them, so a repeated header
+    /// stays visible as separate entries.
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl Reply {
+    fn values(&self, name: &str) -> Vec<&str> {
+        self.headers
+            .iter()
+            .filter(|(n, _)| n == name)
+            .map(|(_, v)| v.as_str())
+            .collect()
+    }
+
+    fn value(&self, name: &str) -> Option<&str> {
+        self.values(name).first().copied()
+    }
+}
+
+/// One HTTP/1.1 exchange on a fresh connection. `Connection: close` means the reply
+/// ends at EOF, so nothing here has to guess a length.
+fn request(s: &Server, method: &str, path: &str, headers: &[(&str, &str)], body: &str) -> Reply {
+    let port = s.port;
+    let mut req =
+        format!("{method} {path} HTTP/1.1\r\nHost: localhost:{port}\r\nConnection: close\r\n");
+    for (k, v) in headers {
+        req.push_str(&format!("{k}: {v}\r\n"));
+    }
+    if !body.is_empty() {
+        req.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+    req.push_str("\r\n");
+    req.push_str(body);
+
+    let mut sock = TcpStream::connect((s.host.as_str(), port))
+        .unwrap_or_else(|e| panic!("connect to {}:{port}: {e}", s.host));
+    sock.set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    sock.write_all(req.as_bytes()).expect("write request");
+    sock.flush().unwrap();
+    let mut raw = Vec::new();
+    sock.read_to_end(&mut raw).expect("read reply");
+    parse(&raw)
+}
+
+fn get(s: &Server, path: &str) -> Reply {
+    request(s, "GET", path, &[], "")
+}
+
+fn parse(raw: &[u8]) -> Reply {
+    let split = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("reply must have a header terminator");
+    let head = String::from_utf8_lossy(&raw[..split]).into_owned();
+    let body_bytes = &raw[split + 4..];
+
+    let mut lines = head.split("\r\n");
+    let status_line = lines.next().expect("status line");
+    let mut parts = status_line.splitn(3, ' ');
+    parts.next();
+    let status: u16 = parts
+        .next()
+        .expect("status code")
+        .parse()
+        .expect("numeric status");
+    let reason = parts.next().unwrap_or("").to_string();
+
+    let headers: Vec<(String, String)> = lines
+        .filter_map(|line| line.split_once(':'))
+        .map(|(n, v)| (n.trim().to_ascii_lowercase(), v.trim().to_string()))
+        .collect();
+
+    let chunked = headers
+        .iter()
+        .any(|(n, v)| n == "transfer-encoding" && v.contains("chunked"));
+    let body = if chunked {
+        dechunk(body_bytes)
+    } else {
+        String::from_utf8_lossy(body_bytes).into_owned()
+    };
+    Reply {
+        status,
+        reason,
+        headers,
+        body,
+    }
+}
+
+/// Node answers a streamed response with `Transfer-Encoding: chunked`, so the wire
+/// form has to be decoded before the body can be compared.
+fn dechunk(mut rest: &[u8]) -> String {
+    let mut out = Vec::new();
+    loop {
+        let Some(eol) = rest.windows(2).position(|w| w == b"\r\n") else {
+            break;
+        };
+        let size_line = String::from_utf8_lossy(&rest[..eol]).into_owned();
+        let size = usize::from_str_radix(size_line.split(';').next().unwrap().trim(), 16)
+            .unwrap_or_else(|_| panic!("bad chunk size {size_line:?}"));
+        rest = &rest[eol + 2..];
+        if size == 0 {
+            break;
+        }
+        out.extend_from_slice(&rest[..size]);
+        rest = &rest[size + 2..];
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+// ── The served shapes ────────────────────────────────────────────────
+
+/// The portable contract: an ES-module default export with a `fetch` method taking a
+/// `Request` and returning a `Response`, reachable over HTTP with no boilerplate.
+#[test]
+fn esm_default_export_is_served() {
+    let s = start("server.mjs", &[]);
+    let r = get(&s, "/greet?q=hi");
+    assert_eq!(r.status, 200, "body was {:?}", r.body);
+    assert_eq!(r.body, "hello from /greet?hi");
+}
+
+/// A `.ts` entry has to be transpiled before its default export exists at all, so
+/// this covers the transpile path as much as the handler one.
+#[test]
+fn typescript_entry_is_served() {
+    let s = start("server.ts", &[]);
+    let r = get(&s, "/nub");
+    assert_eq!(r.status, 200, "body was {:?}", r.body);
+    assert_eq!(r.body, "hello nub");
+}
+
+/// The CommonJS spelling, `module.exports = { fetch }`, which is what a `.ts` entry
+/// in a package without `"type": "module"` also transpiles into.
+#[test]
+fn commonjs_entry_is_served() {
+    let s = start("server.cjs", &[]);
+    assert_eq!(get(&s, "/").body, "hello from commonjs");
+}
+
+/// A handler assembled after a top-level await is still found: the detection pass
+/// awaits the entry's own module job rather than assuming evaluation has landed.
+#[test]
+fn top_level_await_settles_before_detection() {
+    let s = start("tla.mjs", &[]);
+    assert_eq!(get(&s, "/").body, "ready after await");
+}
+
+// ── The request and response bridge ──────────────────────────────────
+
+/// Method, headers and a request body reach the handler, and the handler's status,
+/// headers and body come back out.
+#[test]
+fn request_and_response_round_trip() {
+    let s = start("server.mjs", &[]);
+    let r = request(&s, "POST", "/echo", &[("x-send", "inbound")], "body bytes");
+    assert_eq!(r.status, 201, "body was {:?}", r.body);
+    assert_eq!(
+        r.value("x-method"),
+        Some("POST"),
+        "method reached the handler"
+    );
+    assert_eq!(
+        r.value("x-seen"),
+        Some("inbound"),
+        "request header reached the handler"
+    );
+    assert_eq!(
+        r.body, "body bytes",
+        "request body streamed through to the response"
+    );
+}
+
+/// Two `Set-Cookie` headers stay two headers. The `Headers` iterator joins repeats
+/// with a comma, which corrupts any cookie carrying an `Expires` date, so the writer
+/// reads cookies through `getSetCookie()` instead.
+#[test]
+fn repeated_set_cookie_stays_separate() {
+    let s = start("server.mjs", &[]);
+    let r = get(&s, "/cookies");
+    let cookies = r.values("set-cookie");
+    assert_eq!(
+        cookies,
+        vec!["a=1; Expires=Wed, 21 Oct 2026 07:28:00 GMT", "b=2"],
+        "each Set-Cookie needs its own header line"
+    );
+}
+
+/// A `ReadableStream` body is piped through rather than buffered, and arrives whole.
+#[test]
+fn streamed_body_arrives_complete() {
+    let s = start("server.mjs", &[]);
+    let r = get(&s, "/stream");
+    assert_eq!(r.status, 200);
+    assert_eq!(r.body, "chunk-one\nchunk-two\n");
+}
+
+/// A 204 carries no body, and a HEAD gets the status and headers with none either.
+#[test]
+fn bodyless_responses_send_no_body() {
+    let s = start("server.mjs", &[]);
+    let no_content = get(&s, "/empty");
+    assert_eq!(no_content.status, 204);
+    assert_eq!(no_content.body, "", "a 204 must not carry a body");
+
+    let head = request(&s, "HEAD", "/greet", &[], "");
+    assert_eq!(head.status, 200);
+    assert_eq!(head.body, "", "a HEAD response must not carry a body");
+}
+
+/// A non-default status reason survives the hand-off to `ServerResponse`.
+#[test]
+fn status_and_reason_are_preserved() {
+    let s = start("server.mjs", &[]);
+    let r = get(&s, "/teapot");
+    assert_eq!(r.status, 418);
+    assert_eq!(
+        r.reason, "I'm a Teapot",
+        "Node supplies the reason for a known status"
+    );
+    assert_eq!(r.body, "short and stout");
+}
+
+/// A handler that throws, and one that returns something that is not a `Response`,
+/// both answer 500 rather than hanging the connection — and both report the cause,
+/// the way an uncaught error in user code does.
+#[test]
+fn handler_faults_answer_500_and_report() {
+    let s = start("server.mjs", &[]);
+    assert_eq!(get(&s, "/throw").status, 500);
+    assert_eq!(get(&s, "/not-a-response").status, 500);
+
+    let mut reported = String::new();
+    // Two faults, so two reports; read until both have arrived rather than assuming
+    // either ordering.
+    while !(reported.contains("handler blew up") && reported.contains("must return a Response")) {
+        match s.stderr.recv_timeout(Duration::from_secs(30)) {
+            Ok(line) => reported.push_str(&format!("{line}\n")),
+            Err(_) => panic!("faults were not reported on stderr; saw: {reported}"),
+        }
+    }
+    // The server is still up after both.
+    assert_eq!(get(&s, "/still-here").status, 200);
+}
+
+// ── What must NOT be served ──────────────────────────────────────────
+
+/// A script with no default export, and one whose default export is not a handler,
+/// both run and exit exactly as they do on plain Node. The shape of the user's own
+/// module is the entire gate, so this is the additivity guarantee.
+#[test]
+fn a_file_without_the_shape_is_not_served() {
+    for (name, marker) in [
+        ("plain.mjs", "plain script ran"),
+        ("no-fetch.mjs", "no-fetch script ran"),
+    ] {
+        let (stdout, stderr, code) = run_to_completion(name, &[], &[("PORT", "0")]);
+        assert_eq!(code, 0, "{name} must exit cleanly; stderr: {stderr}");
+        assert!(stdout.contains(marker), "{name} must still run: {stdout:?}");
+        assert!(
+            !stderr.contains("Listening on"),
+            "{name} must not bind a listener: {stderr:?}"
+        );
+    }
+}
+
+/// Compat mode is plain Node, and plain Node does nothing with a default-exported
+/// `fetch`. Both spellings of the opt-out are covered because they are independent
+/// signals: the flag is per-invocation, the variable is tree-wide.
+#[test]
+fn compat_mode_does_not_serve() {
+    for (args, env) in [
+        (["--node"].as_slice(), [("PORT", "0")].as_slice()),
+        (
+            [].as_slice(),
+            [("PORT", "0"), ("NODE_COMPAT", "1")].as_slice(),
+        ),
+    ] {
+        let (_stdout, stderr, code) = run_to_completion("server.mjs", args, env);
+        assert_eq!(code, 0, "must exit cleanly; stderr: {stderr}");
+        assert!(
+            !stderr.contains("Listening on"),
+            "{args:?} / {env:?} must not bind a listener: {stderr:?}"
+        );
+    }
+}
+
+/// The signal is deleted before user code runs, so a child never inherits it. Without
+/// that, a server which forks a worker pool would hand every worker its own port —
+/// and here the child, being the same file, would report a second `Listening on`.
+#[test]
+fn the_serve_signal_does_not_reach_a_child() {
+    let s = start("spawns-child.mjs", &[]);
+    assert_eq!(get(&s, "/").body, "parent handler");
+
+    // Read through the channel, not to EOF: this server stays up, so its stdout never
+    // closes. The child reports its own outcome on the parent's stdout.
+    let mut lines = Vec::new();
+    while !lines
+        .iter()
+        .any(|l: &String| l.starts_with("child-stdout:"))
+    {
+        match s.stdout.recv_timeout(Duration::from_secs(60)) {
+            Ok(line) => lines.push(line),
+            Err(_) => panic!("the child never reported; parent stdout so far: {lines:?}"),
+        }
+    }
+    assert!(
+        lines.contains(&"child-stdout:child ran to completion".to_string()),
+        "the child must run and exit rather than bind: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|l| l.contains("Listening on")),
+        "the child must not report a listener: {lines:?}"
+    );
+}
+
+/// `node <file>` through the PATH hijack keeps meaning what `node` means. Augmenting
+/// the hijack is deliberate, but binding a port is a visible behavior change, so a
+/// script's `node server.js` stays a script run while `nub server.js` serves.
+#[cfg(unix)]
+#[test]
+fn the_node_hijack_does_not_serve() {
+    let dir = std::env::temp_dir().join(format!("nub-fetch-hijack-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let shim = dir.join("node");
+    let _ = std::fs::remove_file(&shim);
+    std::os::unix::fs::symlink(nub_binary(), &shim).unwrap();
+
+    let f = fixture("server.mjs");
+    let out = Command::new(&shim)
+        .arg(&f)
+        .current_dir(f.parent().unwrap())
+        .env("PORT", "0")
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to spawn the node shim");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(
+        out.status.success(),
+        "the shim run must exit cleanly: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Listening on"),
+        "`node <file>` must not bind a listener: {stderr:?}"
+    );
+}
+
+// ── Address selection ───────────────────────────────────────────────
+
+/// `PORT` outranks a `port` the source committed, because an environment that sets it
+/// is a platform placing the process. With `PORT` unset the export's own value is
+/// honored.
+#[test]
+fn port_precedence_puts_the_environment_first() {
+    let s = start("configured.mjs", &[]);
+    assert_ne!(s.port, 41999, "PORT=0 must outrank the export's `port`");
+    assert_eq!(get(&s, "/").body, "configured");
+
+    // The export's value, with nothing in the environment to outrank it. Bound by the
+    // test first so the fixture's own literal is the thing that fails.
+    let held = TcpListener::bind(("127.0.0.1", 41999));
+    if held.is_ok() {
+        drop(held);
+        let f = fixture("configured.mjs");
+        let mut child = Command::new(nub_binary())
+            .arg(&f)
+            .current_dir(f.parent().unwrap())
+            .env_remove("PORT")
+            .stdin(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let err = child.stderr.take().unwrap();
+        let line = BufReader::new(err)
+            .lines()
+            .map_while(Result::ok)
+            .find(|l| l.starts_with("Listening on"));
+        let _ = child.kill();
+        let _ = child.wait();
+        assert_eq!(
+            line.as_deref(),
+            Some("Listening on http://127.0.0.1:41999"),
+            "the export's `port` and `hostname` are honored when the environment is silent"
+        );
+    }
+}
+
+/// `HOST` outranks the export's `hostname`. The fixture asks for `127.0.0.1` and the
+/// environment asks for `localhost`: the same interface, so the server answers either
+/// way, and the reported host is what says which source won.
+#[test]
+fn host_env_outranks_the_export() {
+    let s = start("configured.mjs", &[("HOST", "localhost")]);
+    assert_eq!(get(&s, "/").body, "configured");
+    let reported = format!("Listening on http://localhost:{}", s.port);
+    assert_eq!(
+        s.startup_line, reported,
+        "HOST must outrank the export's `hostname`"
+    );
+}
+
+/// A port already in use is fatal, matching Bun and Deno. Quietly serving a port
+/// nobody asked for is worse than stopping, and a dev loop retries in a second.
+#[test]
+fn a_taken_port_is_fatal() {
+    let held = TcpListener::bind(("127.0.0.1", 0)).expect("bind a port to hold");
+    let taken = held.local_addr().unwrap().port();
+    let (_stdout, stderr, code) = run_to_completion(
+        "server.mjs",
+        &[],
+        &[("PORT", &taken.to_string()), ("HOST", "127.0.0.1")],
+    );
+    assert_eq!(
+        code, 1,
+        "a failed bind must exit non-zero; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("already in use"),
+        "the failure must name the cause: {stderr:?}"
+    );
+}
+
+/// A port the parser rejects fails with the source named, before any socket work.
+#[test]
+fn an_unusable_port_names_its_source() {
+    let (_stdout, stderr, code) = run_to_completion("server.mjs", &[], &[("PORT", "not-a-port")]);
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(stderr.contains("PORT must be an integer"), "got {stderr:?}");
+}

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -173,15 +173,17 @@ fn run_nub_args_against_node(
 }
 
 /// Like `run_nub_args_against_node` for a process that is not expected to exit — a
-/// server. Waits for a stderr line containing `needle` (or the deadline), kills the
-/// process, and hands back whether the line came and everything stdout said.
-fn run_nub_args_until(
+/// server. Waits for a stderr line containing `needle` (or the deadline), hands that
+/// line to `ready` while the process is still up, kills it, and returns what `ready`
+/// made of it (`None` when the line never came) beside everything stdout said.
+fn run_nub_args_until<T>(
     want: (u32, u32, u32),
     fixture: &str,
     args: &[&str],
     needle: &str,
     deadline: Duration,
-) -> Option<(bool, String)> {
+    ready: impl FnOnce(&str) -> T,
+) -> Option<(Option<T>, String)> {
     let bin_dir = find_node_bin_dir(want)?;
     let fixture_path = fixtures_dir().join(fixture);
     let existing = std::env::var_os("PATH").unwrap_or_default();
@@ -217,14 +219,40 @@ fn run_nub_args_until(
     let seen = loop {
         let left = deadline.saturating_sub(started.elapsed());
         match rx.recv_timeout(left) {
-            Ok(line) if line.contains(needle) => break true,
+            Ok(line) if line.contains(needle) => break Some(ready(&line)),
             Ok(_) => continue,
-            Err(_) => break false,
+            Err(_) => break None,
         }
     };
     let _ = child.kill();
     let _ = child.wait();
     Some((seen, stdout.join().unwrap()))
+}
+
+/// One `GET /` against the server a `Listening on http://<host>:<port>` line
+/// announced, as a body. Raw sockets, like the fetch-handler suite: no client crate.
+fn get_root(listening: &str) -> String {
+    use std::io::{Read as _, Write as _};
+    let authority = listening
+        .trim()
+        .strip_prefix("Listening on http://")
+        .unwrap_or_else(|| panic!("not a listening line: {listening:?}"));
+    let (host, port) = authority.rsplit_once(':').unwrap();
+    let host = host.trim_matches(|c| c == '[' || c == ']');
+    let mut stream = std::net::TcpStream::connect((host, port.parse::<u16>().unwrap())).unwrap();
+    stream
+        .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).unwrap();
+    let raw = String::from_utf8_lossy(&raw);
+    let (_, body) = raw.split_once("\r\n\r\n").unwrap();
+    // A short body arrives chunked from node:http; strip the one chunk's framing.
+    let body = body.trim_end_matches("0\r\n\r\n").trim_end();
+    match body.split_once("\r\n") {
+        Some((size, rest)) if usize::from_str_radix(size, 16).is_ok() => rest.to_string(),
+        _ => body.to_string(),
+    }
 }
 
 fn slurp<R: Read + Send + 'static>(mut pipe: R) -> std::thread::JoinHandle<String> {
@@ -1166,6 +1194,7 @@ fn a_rewritten_entry_that_holds_the_loop_is_still_served_once() {
             &["--import", "./rewrite.mjs", "holds.mjs"],
             "Listening on",
             Duration::from_secs(60),
+            |_| (),
         ) else {
             eprintln!(
                 "skipping: Node {maj}.{min}.{pat} not installed \
@@ -1174,12 +1203,53 @@ fn a_rewritten_entry_that_holds_the_loop_is_still_served_once() {
             continue;
         };
         assert!(
-            listening,
+            listening.is_some(),
             "Node {maj}.{min}.{pat}: a handler behind a URL-rewriting hook must still bind: stdout={stdout:?}"
         );
         assert_eq!(
             stdout, "holds:?v=1\n",
             "Node {maj}.{min}.{pat}: the entry must evaluate exactly once, under the rewritten URL"
+        );
+    }
+}
+
+/// A preload that imports the entry ahead of the program under a query of its own
+/// is a second module, not the entry: the load hooks may only take Node's own load
+/// of the entry for it — the one after Node resolved it as the main, with no parent.
+/// Matched on pathname alone, the preload's import was taken for the entry and its
+/// handler served while Node went on to evaluate the real one.
+#[test]
+fn a_preload_import_of_the_entry_is_not_served_in_its_place() {
+    for want in [(22, 13, 0), (20, 11, 0)] {
+        let (maj, min, pat) = want;
+        let Some((body, stdout)) = run_nub_args_until(
+            want,
+            "entry-url-rewrite",
+            &[
+                "--import",
+                "./rewrite.mjs",
+                "--import",
+                "./warm.mjs",
+                "holds.mjs",
+            ],
+            "Listening on",
+            Duration::from_secs(60),
+            get_root,
+        ) else {
+            eprintln!(
+                "skipping: Node {maj}.{min}.{pat} not installed \
+                 (set TEST_NODE_BIN_{maj}_{min}_{pat} or nvm install)"
+            );
+            continue;
+        };
+        assert_eq!(
+            body.as_deref(),
+            Some("held:?v=1"),
+            "Node {maj}.{min}.{pat}: the served handler must be the entry Node loaded, not the preload's copy: stdout={stdout:?}"
+        );
+        assert_eq!(
+            stdout, "holds:?warm\nholds:?v=1\n",
+            "Node {maj}.{min}.{pat}: the preload's copy first, the entry once, and nothing more"
         );
     }
 }

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -15,8 +15,10 @@
 //! `actions/setup-node`, so the gating only hides them on developer
 //! machines that don't have the full nvm matrix.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 fn nub_binary() -> PathBuf {
     let mut path = std::env::current_exe().unwrap();
@@ -123,6 +125,59 @@ fn run_nub_against_node(
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let code = output.status.code().unwrap_or(-1);
     Some((stdout, stderr, code))
+}
+
+/// `run_nub_against_node` for an invocation with Node flags ahead of the file, and
+/// bounded by a deadline: the failure this exists to catch is a process that never
+/// exits, which `Output` alone would wait on forever. The exit code is `None` when
+/// the deadline killed it.
+fn run_nub_args_against_node(
+    want: (u32, u32, u32),
+    fixture: &str,
+    args: &[&str],
+    deadline: Duration,
+) -> Option<(String, String, Option<i32>)> {
+    let bin_dir = find_node_bin_dir(want)?;
+    let fixture_path = fixtures_dir().join(fixture);
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir];
+    paths.extend(std::env::split_paths(&existing));
+    let new_path = std::env::join_paths(paths).expect("join PATH");
+
+    let mut child = Command::new(nub_binary())
+        .args(args)
+        .current_dir(&fixture_path)
+        .env("PATH", new_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nub");
+    // Both pipes drain on their own threads, so a chatty child can neither block
+    // nor be blocked by the wait below.
+    let stdout = slurp(child.stdout.take().unwrap());
+    let stderr = slurp(child.stderr.take().unwrap());
+    let started = Instant::now();
+    let code = loop {
+        if let Some(status) = child.try_wait().expect("wait on nub") {
+            break status.code();
+        }
+        if started.elapsed() > deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    Some((stdout.join().unwrap(), stderr.join().unwrap(), code))
+}
+
+fn slurp<R: Read + Send + 'static>(mut pipe: R) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = pipe.read_to_end(&mut buf);
+        String::from_utf8_lossy(&buf).into_owned()
+    })
 }
 
 /// Node 22.13.0 is the compat-tier representative: above the 18.19 floor,
@@ -997,6 +1052,44 @@ fn esm_preload_awaits_a_macrotask_before_the_entry_on_both_tiers() {
         assert_eq!(
             stdout, "preload:start\npreload:done\nmain:done\n",
             "Node {maj}.{min}.{pat}: the entry must not start until the preload's await settles"
+        );
+    }
+}
+
+/// A foreign resolve hook that rewrites the entry's URL — a cache-busting query, the
+/// shape a hot-reload loader adds — means nub's own hooks never see the entry under
+/// a URL they track, so the fetch-handler pass falls through to `beforeExit`. The
+/// channel the loader worker would have announced the entry on must not hold the
+/// process open meanwhile: a plain script under such a hook has to exit, on the
+/// tiers whose hooks run in that worker. It did not, once — a referenced port kept
+/// every such process alive for good.
+#[test]
+fn a_foreign_hook_rewriting_the_entry_url_does_not_hold_the_process() {
+    for want in [(22, 13, 0), (20, 11, 0)] {
+        let (maj, min, pat) = want;
+        let Some((stdout, stderr, code)) = run_nub_args_against_node(
+            want,
+            "entry-url-rewrite",
+            &["--import", "./rewrite.mjs", "plain.mjs"],
+            Duration::from_secs(60),
+        ) else {
+            eprintln!(
+                "skipping: Node {maj}.{min}.{pat} not installed \
+                 (set TEST_NODE_BIN_{maj}_{min}_{pat} or nvm install)"
+            );
+            continue;
+        };
+
+        assert_eq!(
+            code,
+            Some(0),
+            "Node {maj}.{min}.{pat}: a plain script behind a URL-rewriting hook must exit \
+             rather than hang: stdout={stdout:?} stderr={stderr:?}"
+        );
+        // The rewrite has to have taken, or the run proved nothing about it.
+        assert_eq!(
+            stdout, "plain:?v=1\n",
+            "Node {maj}.{min}.{pat}: the hook must have rewritten the entry's URL"
         );
     }
 }

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -172,6 +172,61 @@ fn run_nub_args_against_node(
     Some((stdout.join().unwrap(), stderr.join().unwrap(), code))
 }
 
+/// Like `run_nub_args_against_node` for a process that is not expected to exit — a
+/// server. Waits for a stderr line containing `needle` (or the deadline), kills the
+/// process, and hands back whether the line came and everything stdout said.
+fn run_nub_args_until(
+    want: (u32, u32, u32),
+    fixture: &str,
+    args: &[&str],
+    needle: &str,
+    deadline: Duration,
+) -> Option<(bool, String)> {
+    let bin_dir = find_node_bin_dir(want)?;
+    let fixture_path = fixtures_dir().join(fixture);
+    let existing = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir];
+    paths.extend(std::env::split_paths(&existing));
+    let new_path = std::env::join_paths(paths).expect("join PATH");
+
+    let mut child = Command::new(nub_binary())
+        .args(args)
+        .current_dir(&fixture_path)
+        .env("PATH", new_path)
+        .env("PORT", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn nub");
+    let stdout = slurp(child.stdout.take().unwrap());
+    let (tx, rx) = std::sync::mpsc::channel();
+    let stderr = child.stderr.take().unwrap();
+    std::thread::spawn(move || {
+        use std::io::BufRead;
+        for line in std::io::BufReader::new(stderr)
+            .lines()
+            .map_while(Result::ok)
+        {
+            if tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+    let started = Instant::now();
+    let seen = loop {
+        let left = deadline.saturating_sub(started.elapsed());
+        match rx.recv_timeout(left) {
+            Ok(line) if line.contains(needle) => break true,
+            Ok(_) => continue,
+            Err(_) => break false,
+        }
+    };
+    let _ = child.kill();
+    let _ = child.wait();
+    Some((seen, stdout.join().unwrap()))
+}
+
 fn slurp<R: Read + Send + 'static>(mut pipe: R) -> std::thread::JoinHandle<String> {
     std::thread::spawn(move || {
         let mut buf = Vec::new();
@@ -1057,12 +1112,13 @@ fn esm_preload_awaits_a_macrotask_before_the_entry_on_both_tiers() {
 }
 
 /// A foreign resolve hook that rewrites the entry's URL — a cache-busting query, the
-/// shape a hot-reload loader adds — means nub's own hooks never see the entry under
-/// a URL they track, so the fetch-handler pass falls through to `beforeExit`. The
-/// channel the loader worker would have announced the entry on must not hold the
-/// process open meanwhile: a plain script under such a hook has to exit, on the
-/// tiers whose hooks run in that worker. It did not, once — a referenced port kept
-/// every such process alive for good.
+/// shape a hot-reload loader adds — must neither hold the process open nor run the
+/// entry twice, on the tiers whose hooks run in a loader worker. Both happened once:
+/// the port that worker announces the entry on was referenced while the pass waited
+/// for an announcement that never came, so a finished plain script never exited; and
+/// the pass then imported the entry by its plain file URL, which the hook — keyed on
+/// the entry having no parent — left alone, so the file evaluated a second time as
+/// a different module. The exact stdout is what catches the second one.
 #[test]
 fn a_foreign_hook_rewriting_the_entry_url_does_not_hold_the_process() {
     for want in [(22, 13, 0), (20, 11, 0)] {
@@ -1086,10 +1142,44 @@ fn a_foreign_hook_rewriting_the_entry_url_does_not_hold_the_process() {
             "Node {maj}.{min}.{pat}: a plain script behind a URL-rewriting hook must exit \
              rather than hang: stdout={stdout:?} stderr={stderr:?}"
         );
-        // The rewrite has to have taken, or the run proved nothing about it.
+        // The rewrite has to have taken, or the run proved nothing about it — and it
+        // has to have run the entry exactly once.
         assert_eq!(
             stdout, "plain:?v=1\n",
-            "Node {maj}.{min}.{pat}: the hook must have rewritten the entry's URL"
+            "Node {maj}.{min}.{pat}: the hook must have rewritten the entry's URL, and the entry must evaluate once"
+        );
+    }
+}
+
+/// The same hook in front of a handler whose module holds the loop: the pass cannot
+/// wait for idleness, so it has to recognize the entry's load under the rewritten
+/// URL — matched without its query — and then import THAT URL, which is the job
+/// Node already made. Matched exactly, the announcement never came and the handler
+/// stayed unbound.
+#[test]
+fn a_rewritten_entry_that_holds_the_loop_is_still_served_once() {
+    for want in [(22, 13, 0), (20, 11, 0)] {
+        let (maj, min, pat) = want;
+        let Some((listening, stdout)) = run_nub_args_until(
+            want,
+            "entry-url-rewrite",
+            &["--import", "./rewrite.mjs", "holds.mjs"],
+            "Listening on",
+            Duration::from_secs(60),
+        ) else {
+            eprintln!(
+                "skipping: Node {maj}.{min}.{pat} not installed \
+                 (set TEST_NODE_BIN_{maj}_{min}_{pat} or nvm install)"
+            );
+            continue;
+        };
+        assert!(
+            listening,
+            "Node {maj}.{min}.{pat}: a handler behind a URL-rewriting hook must still bind: stdout={stdout:?}"
+        );
+        assert_eq!(
+            stdout, "holds:?v=1\n",
+            "Node {maj}.{min}.{pat}: the entry must evaluate exactly once, under the rewritten URL"
         );
     }
 }

--- a/crates/nub-cli/tests/version_tiers.rs
+++ b/crates/nub-cli/tests/version_tiers.rs
@@ -965,3 +965,38 @@ fn cjs_preload_runs_once_after_hooks_on_both_tiers() {
         );
     }
 }
+
+/// A configured ESM preload whose top-level `await` crosses an event-loop turn
+/// still finishes before the entry starts, on both tiers.
+///
+/// The tiers carry it differently, and each is its own way for something armed in
+/// nub's preload to slip between the user's `await` and the entry: the compat
+/// tier's `--import` preload awaits the chain itself, while the fast tier hands the
+/// chain its own `--import` token behind nub's `--require`. The fetch-handler
+/// detection pass did exactly that on the compat tier when it was armed ahead of the
+/// awaited chain — its `setImmediate` landed in the turn the preload's timer yielded,
+/// and its `import()` ran the entry there.
+#[test]
+fn esm_preload_awaits_a_macrotask_before_the_entry_on_both_tiers() {
+    for want in [(22, 13, 0), (22, 15, 0)] {
+        let (maj, min, pat) = want;
+        let Some((stdout, stderr, code)) =
+            run_nub_against_node(want, "esm-preload-await", "main.mjs")
+        else {
+            eprintln!(
+                "skipping: Node {maj}.{min}.{pat} not installed \
+                 (set TEST_NODE_BIN_{maj}_{min}_{pat} or nvm install)"
+            );
+            continue;
+        };
+
+        assert_eq!(
+            code, 0,
+            "Node {maj}.{min}.{pat}: an awaiting .mjs preload must run without aborting: stderr={stderr}"
+        );
+        assert_eq!(
+            stdout, "preload:start\npreload:done\nmain:done\n",
+            "Node {maj}.{min}.{pat}: the entry must not start until the preload's await settles"
+        );
+    }
+}

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -287,11 +287,14 @@ pub const ARGV_ONLY_FLAGS_ENV: &str = "__NUB_ARGV_ONLY_FLAGS";
 /// (`varlock` is a `#!/usr/bin/env node` script) inherits nub's `NODE_OPTIONS` and
 /// so runs this preload itself. A bare flag was consumed there, by the wrapper, and
 /// the application it then launched never saw it. Carrying the argv lets the
-/// preload tell which process it is in: Node has already `path.resolve`d `argv[1]`
-/// by the time a preload runs, so the process whose `argv[1]` one of these tokens
-/// resolves to is the application, and every other one leaves the marker in place
-/// for its child. Rust names no token as THE entry — `nub --require x server.mjs`
-/// puts `x` first — because Node is the one that knows which one it picked.
+/// preload tell which process it is in: the application is the one whose own argv
+/// IS this list from the entry on — Node has already `path.resolve`d `argv[1]` by
+/// the time a preload runs, and everything after the entry reaches `process.argv`
+/// verbatim — and every other process leaves the marker in place for its child.
+/// Rust names no token as THE entry — `nub --require x server.mjs` puts `x` first —
+/// because Node is the one that knows which one it picked; the preload matches the
+/// whole tail rather than any one token, so an argument that happens to name the
+/// wrapper's own bin cannot make the wrapper claim it.
 ///
 /// The application's preload DELETES it before user code runs, which is what keeps
 /// one listener per launch: a `child_process` spawn or a `Worker` copies

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -267,6 +267,24 @@ pub const NEUTRALIZE_LOCALSTORAGE_ENV: &str = "__NUB_NEUTRALIZE_LOCALSTORAGE";
 /// plain-Node user would have seen. Plumbing, not a user-facing option.
 pub const ARGV_ONLY_FLAGS_ENV: &str = "__NUB_ARGV_ONLY_FLAGS";
 
+/// Internal child-process signal marking a spawn as a TOP-LEVEL file run, so the
+/// preload's deferred pass may serve an entry whose default export is a `fetch`
+/// handler (`installServeEntry`, preload-common.cjs). Plumbing, not a user-facing
+/// option: the feature's real gate is the shape of the user's own default export.
+///
+/// Set only by the two launchers a user reaches by typing `nub` — the plain
+/// `nub <file>` run and `nub watch <file>`. Deliberately NOT set for a bin launch
+/// (`nubx`, `nub exec`), for `--node`/`NODE_COMPAT`, or for the `node` PATH hijack:
+/// binding a port is a visible behavior change, and `node <file>` has to keep
+/// meaning what `node` means even inside a subtree the user opted into. A script that
+/// runs `node server.js` therefore gets Node's behavior, while `nub server.js` gets
+/// the listener.
+///
+/// The preload DELETES it before user code runs, which is what keeps one listener per
+/// launch: a `child_process` spawn or a `Worker` copies `process.env` after the delete,
+/// so a server that forks a worker pool does not give every worker its own port.
+pub const SERVE_ENTRY_ENV: &str = "__NUB_SERVE_ENTRY";
+
 /// Internal child-process signal carrying the matrix's runtime V8 flags — the
 /// [`super::feature_matrix::Mitigation::RuntimeV8Flag`] rows — for the preload to turn
 /// on with `v8.setFlagsFromString` the first time it loads a module that needs one.

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -281,7 +281,7 @@ pub const ARGV_ONLY_FLAGS_ENV: &str = "__NUB_ARGV_ONLY_FLAGS";
 /// the listener.
 ///
 /// The value is the launcher's own argv — every token handed to Node after nub's
-/// injected flags, joined by [`SERVE_ENTRY_SEPARATOR`] — and not a bare `1`,
+/// injected flags, as a JSON array ([`serve_entry_marker`]) — and not a bare `1`,
 /// because the process nub spawns is not always the application. An env-owner
 /// loader or a configured `prefix` sits in FRONT of Node, and a Node-based one
 /// (`varlock` is a `#!/usr/bin/env node` script) inherits nub's `NODE_OPTIONS` and
@@ -313,22 +313,14 @@ pub const SERVE_ENTRY_ENV: &str = "__NUB_SERVE_ENTRY";
 /// re-exec of the artifact by its own program.
 pub const COMPILED_SERVE_ENTRY_ENV: &str = "__NUB_COMPILED_SERVE_ENTRY";
 
-/// Joins the tokens of a [`SERVE_ENTRY_ENV`] value. ASCII unit separator: it cannot
-/// appear in an argument a shell hands over, and unlike JSON it has no failure mode
-/// to guard on the reading side.
-pub const SERVE_ENTRY_SEPARATOR: char = '\x1f';
-
 /// The [`SERVE_ENTRY_ENV`] value for a launch whose Node argv (after nub's own
-/// flags) is `tokens`.
+/// flags) is `tokens`: a JSON array of them. An argument may hold any byte but NUL,
+/// so no separator is safe to reserve — ASCII unit separator was, and Node hands it
+/// through `process.argv` unchanged, where it split one argument into two and moved
+/// the entry off its position.
 pub fn serve_entry_marker<'a>(tokens: impl IntoIterator<Item = &'a str>) -> String {
-    let mut value = String::new();
-    for (i, token) in tokens.into_iter().enumerate() {
-        if i > 0 {
-            value.push(SERVE_ENTRY_SEPARATOR);
-        }
-        value.push_str(token);
-    }
-    value
+    serde_json::to_string(&tokens.into_iter().collect::<Vec<_>>())
+        .expect("a list of strings serializes")
 }
 
 /// Internal child-process signal carrying the matrix's runtime V8 flags — the

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -280,10 +280,42 @@ pub const ARGV_ONLY_FLAGS_ENV: &str = "__NUB_ARGV_ONLY_FLAGS";
 /// runs `node server.js` therefore gets Node's behavior, while `nub server.js` gets
 /// the listener.
 ///
-/// The preload DELETES it before user code runs, which is what keeps one listener per
-/// launch: a `child_process` spawn or a `Worker` copies `process.env` after the delete,
-/// so a server that forks a worker pool does not give every worker its own port.
+/// The value is the launcher's own argv — every token handed to Node after nub's
+/// injected flags, joined by [`SERVE_ENTRY_SEPARATOR`] — and not a bare `1`,
+/// because the process nub spawns is not always the application. An env-owner
+/// loader or a configured `prefix` sits in FRONT of Node, and a Node-based one
+/// (`varlock` is a `#!/usr/bin/env node` script) inherits nub's `NODE_OPTIONS` and
+/// so runs this preload itself. A bare flag was consumed there, by the wrapper, and
+/// the application it then launched never saw it. Carrying the argv lets the
+/// preload tell which process it is in: Node has already `path.resolve`d `argv[1]`
+/// by the time a preload runs, so the process whose `argv[1]` one of these tokens
+/// resolves to is the application, and every other one leaves the marker in place
+/// for its child. Rust names no token as THE entry — `nub --require x server.mjs`
+/// puts `x` first — because Node is the one that knows which one it picked.
+///
+/// The application's preload DELETES it before user code runs, which is what keeps
+/// one listener per launch: a `child_process` spawn or a `Worker` copies
+/// `process.env` after the delete, so a server that forks a worker pool does not
+/// give every worker its own port.
 pub const SERVE_ENTRY_ENV: &str = "__NUB_SERVE_ENTRY";
+
+/// Joins the tokens of a [`SERVE_ENTRY_ENV`] value. ASCII unit separator: it cannot
+/// appear in an argument a shell hands over, and unlike JSON it has no failure mode
+/// to guard on the reading side.
+pub const SERVE_ENTRY_SEPARATOR: char = '\x1f';
+
+/// The [`SERVE_ENTRY_ENV`] value for a launch whose Node argv (after nub's own
+/// flags) is `tokens`.
+pub fn serve_entry_marker<'a>(tokens: impl IntoIterator<Item = &'a str>) -> String {
+    let mut value = String::new();
+    for (i, token) in tokens.into_iter().enumerate() {
+        if i > 0 {
+            value.push(SERVE_ENTRY_SEPARATOR);
+        }
+        value.push_str(token);
+    }
+    value
+}
 
 /// Internal child-process signal carrying the matrix's runtime V8 flags — the
 /// [`super::feature_matrix::Mitigation::RuntimeV8Flag`] rows — for the preload to turn

--- a/crates/nub-core/src/node/flags.rs
+++ b/crates/nub-core/src/node/flags.rs
@@ -299,6 +299,17 @@ pub const ARGV_ONLY_FLAGS_ENV: &str = "__NUB_ARGV_ONLY_FLAGS";
 /// give every worker its own port.
 pub const SERVE_ENTRY_ENV: &str = "__NUB_SERVE_ENTRY";
 
+/// The compiled-artifact counterpart of [`SERVE_ENTRY_ENV`], set by the launcher —
+/// or, in a single executable, by the blob's own main (`compile-sea-loader.cjs`) —
+/// and consumed by the compile preamble (`serveCompiledEntry`). A bare `1`: the
+/// program root is the entry by construction, so nothing has to be told apart. Its
+/// own variable rather than the same one because an artifact launched from inside a
+/// nub-augmented process inherits nub's `NODE_OPTIONS` preload, whose claim would
+/// read a bare value as unaddressed and, with no `argv[1]` in the inline shape,
+/// delete it before the preamble looked. Only a top-level launch is marked, never a
+/// re-exec of the artifact by its own program.
+pub const COMPILED_SERVE_ENTRY_ENV: &str = "__NUB_COMPILED_SERVE_ENTRY";
+
 /// Joins the tokens of a [`SERVE_ENTRY_ENV`] value. ASCII unit separator: it cannot
 /// appear in an argument a shell hands over, and unlike JSON it has no failure mode
 /// to guard on the reading side.

--- a/crates/nub-launcher/src/main.rs
+++ b/crates/nub-launcher/src/main.rs
@@ -687,6 +687,20 @@ fn compile_cache_dir(base: &Path, manifest: &Manifest) -> PathBuf {
 }
 
 fn configure_compiled_process_identity(cmd: &mut Command, launcher_path: &Path) {
+    // A top-level launch may serve a default-exported `fetch` handler, as
+    // `nub <file>` would (`serveCompiledEntry`, compile-preamble.mjs). A re-exec of
+    // this executable by its own program — `fork`, `cluster`, `spawn(process.execPath)`
+    // — arrives with the identity variable below already naming THIS launcher, and
+    // is not marked: under `nub <file>` such a child is plain `node` with the marker
+    // already consumed, and never serves. The inherited marker is dropped rather
+    // than passed on for the same reason the mode channel is, below.
+    let relaunched = std::env::var_os(COMPILED_EXEC_PATH_ENV)
+        .is_some_and(|inherited| Path::new(&inherited) == launcher_path);
+    if relaunched {
+        cmd.env_remove(flags::COMPILED_SERVE_ENTRY_ENV);
+    } else {
+        cmd.env(flags::COMPILED_SERVE_ENTRY_ENV, "1");
+    }
     // `Command::env` replaces an inherited value of the same name. Keep the
     // value in child environments: Node workers, fork(), and re-exec inherit it
     // until the preamble establishes their public process identity.

--- a/npm/loader/package.json
+++ b/npm/loader/package.json
@@ -42,6 +42,7 @@
     "pnp-util.cjs",
     "floor-builtin.mjs",
     "cache-evict.mjs",
+    "fetch-serve.cjs",
     "README.md",
     "LICENSE"
   ],

--- a/runtime/compile-preamble.mjs
+++ b/runtime/compile-preamble.mjs
@@ -90,7 +90,7 @@ import { installCompiledFloat16LazyGlobals } from "./compile-lazy-float16.cjs";
 import { installCompiledTemporalLazyGlobal } from "./compile-lazy-temporal.cjs";
 // #endregion
 import { installSyncPolyfills } from "./polyfills.cjs";
-import { installCompiledChildProcess } from "./preload-common.cjs";
+import { installCompiledChildProcess, serveIfHandler } from "./preload-common.cjs";
 // #region nub:polyfill:navigator
 import {
   installNavigatorShim,
@@ -116,7 +116,21 @@ import {
 // executable with nothing on disk.
 import { blobUrlSource, installBlobUrlSupport } from "./worker-blob-url.cjs";
 
+// Whether this process was marked to serve a default-exported `fetch` handler
+// (`flags::COMPILED_SERVE_ENTRY_ENV`) — by the launcher, or by a single executable's
+// own main (compile-sea-loader.cjs). Read and DELETED here, ahead of the program, for
+// the same containment `nub <file>` has: a child the program spawns copies its
+// environment after the marker is gone. Only a top-level launch is marked — a
+// re-exec of the executable by its own program (`fork`, `cluster`,
+// `spawn(process.execPath)`) is not, as under `nub <file>` such a child is plain
+// `node` and never serves.
+let serveEntry = false;
+
 export function installCompilePreamble() {
+  if (process.env.__NUB_COMPILED_SERVE_ENTRY !== undefined) {
+    serveEntry = true;
+    delete process.env.__NUB_COMPILED_SERVE_ENTRY;
+  }
   // Node 18/20 lack process.getBuiltinModule, so keep builtin lookup tied to the
   // early fixed-root bootstrap rather than the bundle or an installed runtime path.
   // #region nub:polyfill:navigator
@@ -187,6 +201,15 @@ export function installCompilePreamble() {
   // #region nub:polyfill:temporal
   installCompiledTemporalLazyGlobal();
   // #endregion
+}
+
+// The program root wrapper calls this with the entry's namespace once the entry
+// has evaluated, top-level await included. An artifact has to reproduce `nub <file>`,
+// not merely `node <file>`, and a server is the program most worth compiling.
+export function serveCompiledEntry(namespace) {
+  if (!serveEntry) return;
+  serveEntry = false;
+  serveIfHandler(namespace.default);
 }
 
 installCompilePreamble();

--- a/runtime/compile-sea-loader.cjs
+++ b/runtime/compile-sea-loader.cjs
@@ -101,6 +101,21 @@
   delete process.env.__NUB_RUNTIME_V8_FLAGS;
   delete process.env.__NUB_ARGV_ONLY_FLAGS;
 
+  // A top-level launch may serve a default-exported `fetch` handler, as `nub <file>`
+  // would (`serveCompiledEntry`, compile-preamble.mjs). The launcher marks its child
+  // from outside; a SEA marks itself — unless this run IS the program re-executing
+  // its own executable (`spawn(process.execPath)`), which under `nub <file>` is
+  // plain `node` with the marker already consumed, and never serves. The identity
+  // variable is the one the launcher publishes for the same test, and publishing it
+  // here is also what stops an artifact launched from inside another one from
+  // inheriting THAT executable's identity as its own.
+  if (process.env.__NUB_COMPILED_EXEC_PATH === process.execPath) {
+    delete process.env.__NUB_COMPILED_SERVE_ENTRY;
+  } else {
+    process.env.__NUB_COMPILED_SERVE_ENTRY = "1";
+  }
+  process.env.__NUB_COMPILED_EXEC_PATH = process.execPath;
+
   if (COMPILE_CACHE_KEY) {
     try {
       // nub's cache root, as `node::discovery::cache_dir` resolves it: the XDG

--- a/runtime/fetch-serve.cjs
+++ b/runtime/fetch-serve.cjs
@@ -1,0 +1,215 @@
+// The HTTP server behind nub's default-export `fetch` handler: an entry whose
+// default export is an object with a `fetch` method is served over HTTP instead of
+// merely evaluated. That is the handler shape Cloudflare Workers, Bun, Deno
+// (`deno serve`) and Vercel all accept, so one file runs unchanged on each of them
+// and under `nub <file>`.
+//
+// Detection lives in preload-common.cjs (`installServeEntry`), which requires THIS
+// module only once it has a handler in hand — so an ordinary script never pays for
+// node:http, and the module list at user code's first line is untouched either way.
+//
+// Contract (decided 2026-05-22): ONE argument,
+// `fetch(request: Request) → Response | Promise<Response>` — the intersection of
+// Workers' `(request, env, ctx)`, Bun's `(request, server)` and Deno's
+// `(request, info)`. A second argument stays additive for whenever WinterTC's
+// http-server proposal settles what belongs in one. Honored option keys on the
+// default export are `port` and `hostname`, nothing else. Pure node:http plus
+// WHATWG Request/Response: no N-API, no Rust listener, and the same adapter shape
+// `srvx` and `@hono/node-server` use on plain Node, which is the escape hatch this
+// feature is reversible through.
+"use strict";
+
+const http = require("node:http");
+const { Readable, pipeline } = require("node:stream");
+const { isIP } = require("node:net");
+
+const DEFAULT_PORT = 3000;
+
+// Bind a listener that routes every request through the handler. Called once, from
+// the detection pass, on the main thread of a process the user launched as a file
+// run — never for a child or a Worker.
+function serve(handler) {
+  let port;
+  let host;
+  try {
+    ({ port, host } = listenOptions(handler, process.env));
+  } catch (err) {
+    fail(err.message);
+  }
+  const server = http.createServer((req, res) => {
+    handle(handler, req, res);
+  });
+  // A failed bind is fatal, matching Bun and Deno: silently serving a port nobody
+  // asked for is worse than stopping, and a dev loop retries in a second.
+  server.on("error", (err) => {
+    const where = host ? `${host}:${port}` : `port ${port}`;
+    if (err.code === "EADDRINUSE") {
+      fail(`${where} is already in use (set PORT to choose another port)`);
+    }
+    if (err.code === "EACCES") {
+      fail(`${where} needs elevated privileges (set PORT to choose another port)`);
+    }
+    fail(err.message);
+  });
+  server.listen(port, host, () => {
+    process.stderr.write(`Listening on ${displayUrl(host, server.address().port)}\n`);
+  });
+}
+
+// `PORT` > the export's `port` > 3000, and `HOST` > the export's `hostname` > every
+// interface. `PORT` is the one signal every platform-as-a-service agrees on, and
+// Bun, Express and Next all read it, so an environment that sets it has to win over
+// a port literal the source committed. Leaving the host undefined hands Node its own
+// dual-stack default rather than pinning IPv4.
+function listenOptions(handler, env) {
+  const port = parsePort(env.PORT, "PORT")
+    ?? parsePort(handler.port, "the default export's `port`")
+    ?? DEFAULT_PORT;
+  const host = nonEmpty(env.HOST) ?? nonEmpty(handler.hostname) ?? undefined;
+  return { port, host };
+}
+
+function parsePort(value, source) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const n = typeof value === "number" ? value : Number(String(value).trim());
+  if (!Number.isInteger(n) || n < 0 || n > 65535) {
+    throw new Error(`${source} must be an integer from 0 to 65535, got ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+}
+
+// What to print for a host the user can actually open. A wildcard bind is reachable
+// at localhost, and a bare IPv6 literal needs brackets to be a valid URL.
+function displayUrl(host, port) {
+  let shown = "localhost";
+  if (host && host !== "0.0.0.0" && host !== "::") {
+    shown = isIP(host) === 6 ? `[${host}]` : host;
+  }
+  return `http://${shown}:${port}`;
+}
+
+function fail(message) {
+  process.stderr.write(`nub: ${message}\n`);
+  process.exit(1);
+}
+
+async function handle(handler, req, res) {
+  // The handler observes a disconnect through `request.signal`, the only channel the
+  // one-argument contract has for it. Firing on `close` before the response finished
+  // covers both a client that went away and a response we destroyed.
+  const controller = new AbortController();
+  res.on("close", () => {
+    if (!res.writableFinished) controller.abort();
+  });
+  let request;
+  try {
+    request = toRequest(req, controller.signal);
+  } catch {
+    // A request line or Host header no WHATWG URL can express, or a method `Request`
+    // forbids (CONNECT, TRACE, TRACK). Never reaches the handler.
+    plain(res, 400, "Bad Request");
+    return;
+  }
+  let response;
+  try {
+    response = await handler.fetch(request);
+    if (!isResponse(response)) {
+      throw new TypeError(`fetch handler must return a Response, got ${describe(response)}`);
+    }
+  } catch (err) {
+    if (controller.signal.aborted) return;
+    // The handler's bug, reported the way an uncaught error in user code is, and
+    // answered rather than left to hang. Headers already on the wire mean the status
+    // is spent, so the only honest signal left is an incomplete response.
+    console.error(err);
+    if (res.headersSent) res.destroy();
+    else plain(res, 500, "Internal Server Error");
+    return;
+  }
+  try {
+    writeResponse(res, response, req.method === "HEAD");
+  } catch (err) {
+    console.error(err);
+    res.destroy();
+  }
+}
+
+// IncomingMessage → Request. `rawHeaders` keeps a repeated header as separate
+// entries, which `req.headers` has already joined; the body rides the request stream
+// itself, and `duplex: "half"` is what undici requires of any streamed body. GET and
+// HEAD get none because `Request` rejects a body on either.
+function toRequest(req, signal) {
+  const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+  const headers = new Headers();
+  const raw = req.rawHeaders;
+  for (let i = 0; i < raw.length; i += 2) headers.append(raw[i], raw[i + 1]);
+  const method = req.method;
+  if (method === "GET" || method === "HEAD") {
+    return new Request(url, { method, headers, signal });
+  }
+  // `duplex` is only meaningful alongside a body, and passing it without one is an
+  // option undici has no reason to keep accepting.
+  return new Request(url, { method, headers, body: Readable.toWeb(req), duplex: "half", signal });
+}
+
+// A Response from another realm — a Worker's, or a polyfill a dependency installed —
+// fails `instanceof`, so accept anything carrying the shape the writer below reads.
+function isResponse(value) {
+  if (value instanceof Response) return true;
+  return isObject(value)
+    && typeof value.status === "number"
+    && isObject(value.headers)
+    && typeof value.headers.forEach === "function";
+}
+
+function isObject(value) {
+  return typeof value === "object" && value !== null;
+}
+
+function describe(value) {
+  if (value === null) return "null";
+  if (typeof value !== "object") return typeof value;
+  const name = value.constructor && value.constructor.name;
+  return name ? `an instance of ${name}` : "an object";
+}
+
+// Response → ServerResponse. Cookies come from `getSetCookie()` so each one keeps
+// its own header line — the Headers iterator joins them with a comma, which breaks
+// any cookie carrying an `Expires` date. A HEAD, 204 or 304 response sends no body,
+// and a body nothing will read is cancelled rather than left for the collector.
+function writeResponse(res, response, isHead) {
+  const { status, headers } = response;
+  for (const [name, value] of headers) {
+    if (name === "set-cookie") continue;
+    res.setHeader(name, value);
+  }
+  const cookies = typeof headers.getSetCookie === "function"
+    ? headers.getSetCookie()
+    : headers.has("set-cookie")
+      ? [headers.get("set-cookie")]
+      : [];
+  if (cookies.length > 0) res.setHeader("set-cookie", cookies);
+  res.writeHead(status, response.statusText || undefined);
+  const body = response.body;
+  if (body === null || isHead || status === 204 || status === 304) {
+    if (body !== null) body.cancel().catch(() => {});
+    res.end();
+    return;
+  }
+  // pipeline owns backpressure and teardown in both directions: a client that goes
+  // away destroys the source, which cancels the web stream, and a source that fails
+  // destroys the response instead of leaving the request open.
+  pipeline(Readable.fromWeb(body), res, () => {});
+}
+
+function plain(res, status, text) {
+  res.statusCode = status;
+  res.setHeader("content-type", "text/plain;charset=UTF-8");
+  res.end(text);
+}
+
+module.exports = { serve, listenOptions, displayUrl, isResponse };

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -71,9 +71,23 @@ const __pnp = (() => {
 // reads — without the clear here, `import "@js-temporal/polyfill"` on the
 // compat tier resolved to a synthetic re-export of a global the loader never
 // installs, silently binding `undefined` (verified on Node 20.19). The nub CLI
-// registers this worker with no data, keeping its clobbers intact.
+// registers this worker with no data, keeping its clobbers intact — except for the
+// fetch-handler case below, which carries no clobber flag.
+//
+// `{ entryLoad: { port, urls } }` is the main thread waiting to learn that Node has
+// started loading the program entry (preload-common.cjs `noteEntryLoad`): its
+// fetch-handler pass may not `import()` the entry while a preload could still be
+// pending, and this worker is the only place that tier can see the entry go by.
+// Sent only when that wait is actually needed, and answered exactly once.
+let entryLoad = null;
+
 export async function initialize(data) {
   if (data && data.standaloneLoader) CLOBBER_MAP.clear();
+  if (data && data.entryLoad) {
+    entryLoad = { port: data.entryLoad.port, urls: new Set(data.entryLoad.urls) };
+    // Its liveness is the main thread's concern; the worker must not stay up for it.
+    entryLoad.port.unref();
+  }
 }
 
 // ── Resolve hook ────────────────────────────────────────────────────
@@ -97,6 +111,11 @@ export async function resolve(specifier, context, nextResolve) {
 // see transform-core `noteRuntimeV8FlagSource`. Awaited here because the
 // `nextLoad` branch of loadInner hands back a promise on this tier.
 export async function load(url, context, nextLoad) {
+  if (entryLoad !== null && entryLoad.urls.has(url)) {
+    const { port } = entryLoad;
+    entryLoad = null;
+    port.postMessage(url);
+  }
   return noteRuntimeV8FlagSource(await loadInner(url, context, nextLoad));
 }
 

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -84,7 +84,11 @@ let entryLoad = null;
 export async function initialize(data) {
   if (data && data.standaloneLoader) CLOBBER_MAP.clear();
   if (data && data.entryLoad) {
-    entryLoad = { port: data.entryLoad.port, urls: new Set(data.entryLoad.urls) };
+    entryLoad = {
+      port: data.entryLoad.port,
+      urls: new Set(data.entryLoad.urls),
+      mainResolved: false,
+    };
     // Its liveness is the main thread's concern; the worker must not stay up for it.
     entryLoad.port.unref();
   }
@@ -99,6 +103,17 @@ function withoutQuery(url) {
 
 // ── Resolve hook ────────────────────────────────────────────────────
 export async function resolve(specifier, context, nextResolve) {
+  // Node resolves its main entry with no parent and nothing else that way, so only
+  // a load after this can be the entry's own — not a preload's import of the same
+  // file under another query (preload-common.cjs `noteEntryResolve`).
+  if (
+    entryLoad !== null &&
+    !entryLoad.mainResolved &&
+    context.parentURL === undefined &&
+    entryLoad.urls.has(withoutQuery(String(specifier)))
+  ) {
+    entryLoad.mainResolved = true;
+  }
   const r = resolveSpec(specifier, context.parentURL);
   if (r) return r;
   // Yarn PnP: resolve deps through PnP's own resolver — identical to the fast tier,
@@ -118,7 +133,7 @@ export async function resolve(specifier, context, nextResolve) {
 // see transform-core `noteRuntimeV8FlagSource`. Awaited here because the
 // `nextLoad` branch of loadInner hands back a promise on this tier.
 export async function load(url, context, nextLoad) {
-  if (entryLoad !== null && entryLoad.urls.has(withoutQuery(url))) {
+  if (entryLoad !== null && entryLoad.mainResolved && entryLoad.urls.has(withoutQuery(url))) {
     const { port } = entryLoad;
     entryLoad = null;
     port.postMessage(url);

--- a/runtime/preload-async-hooks.mjs
+++ b/runtime/preload-async-hooks.mjs
@@ -90,6 +90,13 @@ export async function initialize(data) {
   }
 }
 
+// The tracked URLs carry no query or fragment; a foreign resolve hook ahead of this
+// one may have added either to the entry's (preload-common.cjs `entryUrls`).
+function withoutQuery(url) {
+  const cut = url.search(/[?#]/);
+  return cut < 0 ? url : url.slice(0, cut);
+}
+
 // ── Resolve hook ────────────────────────────────────────────────────
 export async function resolve(specifier, context, nextResolve) {
   const r = resolveSpec(specifier, context.parentURL);
@@ -111,7 +118,7 @@ export async function resolve(specifier, context, nextResolve) {
 // see transform-core `noteRuntimeV8FlagSource`. Awaited here because the
 // `nextLoad` branch of loadInner hands back a promise on this tier.
 export async function load(url, context, nextLoad) {
-  if (entryLoad !== null && entryLoad.urls.has(url)) {
+  if (entryLoad !== null && entryLoad.urls.has(withoutQuery(url))) {
     const { port } = entryLoad;
     entryLoad = null;
     port.postMessage(url);

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -2040,21 +2040,36 @@ function closeEntryChannel(entry) {
 // front of that application? An env-owner loader or a configured `prefix` runs
 // BEFORE Node in the spawn chain, and a Node-based one (`varlock` is a
 // `#!/usr/bin/env node` script) inherits nub's NODE_OPTIONS and so runs this very
-// preload; a bare flag was consumed there and never reached the application. The
-// marker carries the launcher's argv instead, and Node has already `path.resolve`d
-// `argv[1]` by the time a preload runs, so the same call over each token is an
-// exact test — no second resolver, and no path spelling Rust and Node could
-// disagree on. A wrapper's own `argv[1]` is its bin, which no launcher token names,
-// so it leaves the marker in place for its child. The raw comparison covers `-`
-// (stdin), which Node does not expand. No `argv[1]` at all — `-e`, the REPL — is
-// nothing to serve and nothing to forward, so it counts as this process and the
-// caller deletes the marker.
+// preload; a bare flag was consumed there and never reached the application.
+//
+// The marker carries the launcher's argv instead — Node flags, the entry, then the
+// application's arguments — and the application is the process whose own argv IS
+// that list from the entry on: `argv[1]` resolves to one token, and everything after
+// it is `argv.slice(2)` verbatim, since Node stops parsing at the entry and passes
+// the rest through untouched. Which token is the entry is not something Rust can
+// name (`nub --require x server.mjs` puts `x` first), but the tail length pins it
+// to exactly one position, so no other token is ever a candidate. That is what
+// keeps an argument from impersonating the entry: `nub server.mjs
+// node_modules/.bin/varlock` would otherwise let the wrapper — whose `argv[1]` IS
+// that bin — claim the marker and starve the application of it. A wrapper is
+// always handed the command it runs, so its argv tail is longer than the marker's
+// and the equality can never hold there.
+//
+// Node has already `path.resolve`d `argv[1]` by the time a preload runs, so the same
+// call is an exact test — no second resolver, and no path spelling Rust and Node
+// could disagree on. The raw comparison covers `-` (stdin), which Node does not
+// expand. No `argv[1]` at all — `-e`, the REPL — is nothing to serve and nothing to
+// forward, so it counts as this process and the caller deletes the marker.
 function markedEntryIsThisProcess(marker) {
   const main = process.argv[1];
   if (typeof main !== "string") return true;
-  return marker
-    .split(SERVE_ENTRY_SEPARATOR)
-    .some((token) => token !== "" && (token === main || pathResolve(token) === main));
+  const tokens = marker.split(SERVE_ENTRY_SEPARATOR);
+  const rest = process.argv.slice(2);
+  const at = tokens.length - rest.length - 1;
+  if (at < 0) return false;
+  const entry = tokens[at];
+  if (entry === "" || (entry !== main && pathResolve(entry) !== main)) return false;
+  return rest.every((arg, i) => arg === tokens[at + 1 + i]);
 }
 
 // Could a preload still run after nub's own? True whenever an `--import`/`--loader`

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1888,8 +1888,8 @@ const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
 // The entry this process was marked to serve, from `claimServeEntry` on: the file as
 // Node resolved it, the URLs a load hook may see it under, whether a preload may
 // still follow nub's own, and the state the late pass waits on — whether a hook has
-// seen Node start loading the entry, and what to run when one does. Null in every
-// process that is not the marked application.
+// seen Node start loading the entry, the URL it saw it under, and what to run when
+// one does. Null in every process that is not the marked application.
 let serveEntry = null;
 
 // FIRST in each preload entry, before any user code — the configured preload chain
@@ -1909,6 +1909,7 @@ function claimServeEntry() {
     mayFollow: anotherPreloadMayFollow(),
     taken: false,
     loadSeen: false,
+    loadUrl: null,
     onLoad: null,
     channel: null,
   };
@@ -1983,9 +1984,13 @@ function installServeEntry() {
   });
 }
 
-// The URLs a load hook may see the entry under. Node's ESM resolver hands the hook
-// the realpath unless symlinks are preserved, and `_findPath` has usually resolved it
-// already — so both spellings are watched rather than guessing which one applies.
+// The URLs a load hook may see the entry under, matched without query or fragment.
+// Node's ESM resolver hands the hook the realpath unless symlinks are preserved, and
+// `_findPath` has usually resolved it already — so both spellings are watched rather
+// than guessing which one applies. A foreign resolve hook may add a query — the
+// cache-busting `?v=…` a hot-reload loader appends — and that is still the entry;
+// one that points the entry at another file has made it a different module, and
+// no URL of ours will ever name it.
 function entryUrls(file) {
   const urls = new Set([pathToFileURL(file).href]);
   try {
@@ -1999,9 +2004,15 @@ function entryUrls(file) {
 // `loaderWorkerOptions` hands it. Free in every process but the marked application.
 function noteEntryLoad(url) {
   const entry = serveEntry;
-  if (entry === null || entry.loadSeen || !entry.urls.has(url)) return;
+  if (entry === null || entry.loadSeen || !entry.urls.has(withoutQuery(url))) return;
   entry.loadSeen = true;
+  entry.loadUrl = url;
   fireEntryLoad(entry);
+}
+
+function withoutQuery(url) {
+  const cut = url.search(/[?#]/);
+  return cut < 0 ? url : url.slice(0, cut);
 }
 
 function fireEntryLoad(entry) {
@@ -2133,7 +2144,11 @@ function anotherPreloadMayFollow() {
 // CommonJS one the ESM loader owns on the `--import` compat tier — is reached through
 // `import()`, which returns the job Node already created for that URL. So the entry
 // evaluates exactly once whichever of us gets there first, and the promise settles
-// only after the entry's own top-level await does. Getting there first would cost the
+// only after the entry's own top-level await does. The URL imported is the one a
+// load hook saw the entry under, when one did: a foreign resolve hook that rewrote
+// the entry for Node's own import — a cache-busting query keyed on the entry having
+// no parent, say — would not rewrite nub's, and importing the file's plain URL then
+// evaluates the entry a second time as a different module. Getting there first would cost the
 // entry its `isEntryPoint` flag, and with it `import.meta.main`; on the fast tier the
 // `--require` preload is synchronous, so Node's own import runs in the same macrotask
 // that scheduled the pass, and the compat tier is Node ≤ 22.14, which has no
@@ -2151,7 +2166,7 @@ async function serveEntryIfHandler(entry, mayImport) {
   entry.taken = true;
   let ns;
   try {
-    ns = await import(pathToFileURL(entry.file).href);
+    ns = await import(entry.loadUrl ?? pathToFileURL(entry.file).href);
   } catch {
     // The entry threw. Node has already reported that as an uncaught error, and this
     // is the same failure observed a second time, so it is dropped rather than

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1934,8 +1934,15 @@ function claimServeEntry() {
 //      loop is doing, which is what serves a handler whose preload or module body
 //      holds a timer, a socket or a Worker for good.
 //   3. `beforeExit`, for the hook configuration in which nub's hooks never see the
-//      entry at all. It fires only once the loop drains, so it is the last resort
-//      and never the only one.
+//      entry at all — a foreign resolve hook that rewrites the entry's URL, say. It
+//      fires only once the loop drains, so it is the last resort and never the only
+//      one.
+//
+// Nothing here holds the loop open to wait for trigger 2. The loader worker's channel
+// stays unreferenced: a loop the entry or a preload keeps alive delivers its message
+// regardless, and a loop that drains reaches trigger 3, which inspects the entry
+// without it. Referencing the port instead held EVERY process whose hooks never saw
+// the entry's URL open for good, a finished plain script included.
 //
 // Declining to serve remains the right side to fail on where none of the three can
 // fire: reordering a user's preloads is a correctness break, and not binding a port
@@ -1971,9 +1978,6 @@ function installServeEntry() {
         // `nub <file>` run carry it.
         entry.onLoad = late;
         if (entry.loadSeen) fireEntryLoad(entry);
-        // The worker's signal has to reach a live loop, so the port holds the process
-        // open until it does; `closeEntryChannel` lets go afterwards.
-        if (entry.channel !== null) entry.channel.port1.ref();
         process.once("beforeExit", late);
       })
       .catch(report);
@@ -2020,7 +2024,8 @@ function loaderWorkerOptions() {
   const { MessageChannel } = getBuiltin("node:worker_threads");
   const channel = new MessageChannel();
   channel.port1.on("message", noteEntryLoad);
-  // Referenced only once the pass is actually waiting — see `installServeEntry`.
+  // Never referenced, so an announcement that never comes cannot hold the process
+  // open — see the triggers above `installServeEntry`.
   channel.port1.unref();
   entry.channel = channel;
   return {

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1891,10 +1891,11 @@ function installServeEntry() {
   // this pass, or a server whose module body does nothing asynchronous would exit
   // before it could bind.
   setImmediate(() => {
-    serveEntryIfHandler().catch(() => {
-      // An entry that threw has already been reported by Node as an uncaught
-      // error; re-surfacing our own view of it would double the report, and
-      // leaving this promise unhandled would itself change the exit path.
+    // Nothing below is expected to reject — a throwing entry is handled inside — so
+    // anything arriving here is nub's own defect and is named as such. Leaving the
+    // promise unhandled instead would change the process's exit path.
+    serveEntryIfHandler().catch((err) => {
+      process.stderr.write(`nub: could not inspect the entry for a fetch handler: ${err}\n`);
     });
   });
 }
@@ -1902,7 +1903,16 @@ function installServeEntry() {
 async function serveEntryIfHandler() {
   const file = mainEntryPath();
   if (!file) return;
-  const handler = fetchHandler(await entryDefaultExport(file));
+  let exported;
+  try {
+    exported = await entryDefaultExport(file);
+  } catch {
+    // The entry threw. Node has already reported that as an uncaught error, and this
+    // is the same failure observed a second time, so it is dropped rather than
+    // doubling the report.
+    return;
+  }
+  const handler = fetchHandler(exported);
   if (!handler) return;
   // Required only now, so an ordinary file run never loads node:http at all.
   require("./fetch-serve.cjs").serve(handler);

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -2219,6 +2219,8 @@ module.exports = {
   claimServeEntry,
   loaderWorkerOptions,
   installServeEntry,
+  // For compiled artifacts, whose program root hands the entry over itself.
+  serveIfHandler,
   // Exported for the unit test that asserts which default-export shapes are served.
   fetchHandler,
   requireUserPreloadChain,

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1879,39 +1879,119 @@ function installThreadpoolPolicy() {
 // listener — no `worker_threads` probe needed here to tell the realms apart.
 const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
 
+// NEVER START THE ENTRY OURSELVES BEFORE NODE WOULD HAVE. The inspection below can
+// reach the entry through `import()`, and an `import()` that lands while a preload is
+// still pending EVALUATES THE ENTRY EARLY — ahead of the very preloads that exist to
+// set its realm up. That is not theoretical: a single `setImmediate` here put the
+// entry between two chained preload entries on Node 18.19 and 20.11, which is exactly
+// the additivity guarantee this feature is supposed to preserve. So the pass is armed
+// on two triggers, neither of which can get there first:
+//
+//   1. A `setImmediate`, which reads a CommonJS entry straight off `process.mainModule`
+//      and imports NOTHING. `Module.runMain` is synchronous, so a CommonJS entry has
+//      finished by the check phase. It may only `import()` when no preload can still
+//      follow nub's own — see `anotherPreloadMayFollow`.
+//   2. `beforeExit`, which fires when the loop drains, and therefore strictly after
+//      every preload AND the entry have run. Importing is unconditionally safe here
+//      because there is nothing left to front-run, and a `beforeExit` listener may do
+//      async work, which is what keeps the process alive once a listener binds.
+//
+// Between them the only entry that goes unserved is one reached through `import()`
+// whose module body keeps the loop busy forever WHILE a foreign preload token exists.
+// Declining to serve is the right side to fail on: reordering a user's preloads is a
+// correctness break, and not binding a port is not.
 function installServeEntry() {
   if (!process.env[SERVE_ENTRY_ENV]) return;
   delete process.env[SERVE_ENTRY_ENV];
-  // Deferred, because the entry has not been evaluated yet — the preload runs
-  // first, by construction. One `setImmediate` is enough for a CommonJS entry
-  // (`Module.runMain` is synchronous, so it has finished by the check phase); an ES
-  // module entry may still be mid-evaluation, which is why the resolution below
-  // awaits Node's own module job instead of assuming anything has landed.
-  // `.unref()` is deliberately NOT called: a synchronous script must still reach
-  // this pass, or a server whose module body does nothing asynchronous would exit
-  // before it could bind.
+  const report = (err) => {
+    // A throwing entry is handled inside, so nothing here is expected to reject and
+    // anything that does is nub's own defect, named as such. Leaving the promise
+    // unhandled instead would change the process's exit path.
+    process.stderr.write(`nub: could not inspect the entry for a fetch handler: ${err}\n`);
+  };
+  const claim = { taken: false };
+  // Not `.unref()`d: a synchronous script must still reach this pass, or a server
+  // whose module body does nothing asynchronous would exit before binding.
   setImmediate(() => {
-    // Nothing below is expected to reject — a throwing entry is handled inside — so
-    // anything arriving here is nub's own defect and is named as such. Leaving the
-    // promise unhandled instead would change the process's exit path.
-    serveEntryIfHandler().catch((err) => {
-      process.stderr.write(`nub: could not inspect the entry for a fetch handler: ${err}\n`);
-    });
+    serveEntryIfHandler(claim, !anotherPreloadMayFollow())
+      .then((deferred) => {
+        // The `beforeExit` trigger is registered ONLY when the pass above declined
+        // for want of permission to import — never on an ordinary run. A listener
+        // added up front is observable to the user's own code
+        // (`process.listenerCount("beforeExit")` reads 1 where plain Node reads 0),
+        // and an unconditional one made every `nub <file>` run carry it.
+        if (deferred) {
+          process.once("beforeExit", () => {
+            serveEntryIfHandler(claim, true).catch(report);
+          });
+        }
+      })
+      .catch(report);
   });
 }
 
-async function serveEntryIfHandler() {
-  const file = mainEntryPath();
-  if (!file) return;
-  let exported;
+// Could a preload still run after nub's own? True whenever an `--import`/`--loader`
+// token names anything but nub's own preload — a user entry on its own token, or the
+// preload chainer when the spawn path gave it one instead of loading it from inside
+// nub's preload. Deliberately conservative, and deliberately not
+// `foreignAsyncLoaderFlagPresent`, whose question is a different one: it treats the
+// chainer as nub's own (correct for tier selection, wrong here, since the chainer is
+// precisely what must not be front-run) and reads nub's compat-tier `--import` as
+// foreign.
+function anotherPreloadMayFollow() {
+  const ourDir = dirname(__filename);
+  let tokens = "";
   try {
-    exported = await entryDefaultExport(file);
+    if (Array.isArray(process.execArgv)) tokens += process.execArgv.join(" ");
+  } catch { /* execArgv unavailable — the NODE_OPTIONS channel still answers */ }
+  const opts = process.env.NODE_OPTIONS;
+  if (typeof opts === "string") tokens += ` ${opts}`;
+  const re = /(?:^|\s)--(?:experimental[-_])?(?:import|loader)(?:=|\s)("[^"]*"|\S*)/g;
+  for (const match of tokens.matchAll(re)) {
+    const value = (match[1] || "").replace(/^"|"$/g, "");
+    if (value === "") continue;
+    let path = value;
+    if (path.startsWith("file:")) {
+      try { path = fileURLToPath(path); } catch { return true; }
+    }
+    if (dirname(path) !== ourDir) return true;
+  }
+  return false;
+}
+
+// Serve the entry if its default export is a handler. Resolves TRUE when it declined
+// only because it may not import yet, which is the caller's signal to arm the late
+// trigger. `claim` is shared by both triggers: whichever gets a usable namespace takes
+// it SYNCHRONOUSLY, before any await, so the two can never both bind a listener.
+async function serveEntryIfHandler(claim, mayImport) {
+  if (claim.taken) return false;
+  const file = mainEntryPath();
+  if (!file) {
+    claim.taken = true;
+    return false;
+  }
+  const main = process.mainModule;
+  if (main && main.loaded && main.filename === file) {
+    claim.taken = true;
+    serveIfHandler(main.exports);
+    return false;
+  }
+  if (!mayImport) return true;
+  claim.taken = true;
+  let ns;
+  try {
+    ns = await import(pathToFileURL(file).href);
   } catch {
     // The entry threw. Node has already reported that as an uncaught error, and this
     // is the same failure observed a second time, so it is dropped rather than
     // doubling the report.
-    return;
+    return false;
   }
+  serveIfHandler(ns.default);
+  return false;
+}
+
+function serveIfHandler(exported) {
   const handler = fetchHandler(exported);
   if (!handler) return;
   // Required only now, so an ordinary file run never loads node:http at all.

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1872,12 +1872,17 @@ function installThreadpoolPolicy() {
 // what keeps this additive.
 //
 // The launcher sets SERVE_ENTRY_ENV for a top-level `nub <file>` and `nub watch`
-// only (never `--node`, never a bin launch, never the `node` hijack), and this
-// function DELETES it before any user code runs. That delete is the whole
-// containment: a `child_process` spawn or a Worker copies `process.env` after it is
-// gone, so a server entry that forks a worker pool does not hand every worker its own
-// listener — no `worker_threads` probe needed here to tell the realms apart.
+// only (never `--node`, never a bin launch, never the `node` hijack), and the
+// application's preload DELETES it before any user code runs. That delete is the
+// whole containment: a `child_process` spawn or a Worker copies `process.env` after
+// it is gone, so a server entry that forks a worker pool does not hand every worker
+// its own listener — no `worker_threads` probe needed here to tell the realms apart.
+//
+// Its value is the launcher's argv, tokens joined by SERVE_ENTRY_SEPARATOR, and
+// that is what makes "the application's preload" a process this code can identify:
+// see `markedEntryIsThisProcess`.
 const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
+const SERVE_ENTRY_SEPARATOR = "\x1f";
 
 // NEVER START THE ENTRY OURSELVES BEFORE NODE WOULD HAVE. The inspection below can
 // reach the entry through `import()`, and an `import()` that lands while a preload is
@@ -1901,7 +1906,9 @@ const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
 // Declining to serve is the right side to fail on: reordering a user's preloads is a
 // correctness break, and not binding a port is not.
 function installServeEntry() {
-  if (!process.env[SERVE_ENTRY_ENV]) return;
+  const marker = process.env[SERVE_ENTRY_ENV];
+  if (marker === undefined) return;
+  if (!markedEntryIsThisProcess(marker)) return;
   delete process.env[SERVE_ENTRY_ENV];
   const report = (err) => {
     // A throwing entry is handled inside, so nothing here is expected to reject and
@@ -1928,6 +1935,27 @@ function installServeEntry() {
       })
       .catch(report);
   });
+}
+
+// Is this process the application the launcher marked, or a wrapper it put in
+// front of that application? An env-owner loader or a configured `prefix` runs
+// BEFORE Node in the spawn chain, and a Node-based one (`varlock` is a
+// `#!/usr/bin/env node` script) inherits nub's NODE_OPTIONS and so runs this very
+// preload; a bare flag was consumed there and never reached the application. The
+// marker carries the launcher's argv instead, and Node has already `path.resolve`d
+// `argv[1]` by the time a preload runs, so the same call over each token is an
+// exact test — no second resolver, and no path spelling Rust and Node could
+// disagree on. A wrapper's own `argv[1]` is its bin, which no launcher token names,
+// so it leaves the marker in place for its child. The raw comparison covers `-`
+// (stdin), which Node does not expand. No `argv[1]` at all — `-e`, the REPL — is
+// nothing to serve and nothing to forward, so it counts as this process and the
+// caller deletes the marker.
+function markedEntryIsThisProcess(marker) {
+  const main = process.argv[1];
+  if (typeof main !== "string") return true;
+  return marker
+    .split(SERVE_ENTRY_SEPARATOR)
+    .some((token) => token !== "" && (token === main || pathResolve(token) === main));
 }
 
 // Could a preload still run after nub's own? True whenever an `--import`/`--loader`

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -22,7 +22,7 @@ const getBuiltin = typeof compileBootstrap?.getBuiltin === "function"
 const module_ = getBuiltin("node:module");
 const { readdirSync, existsSync } = getBuiltin("node:fs");
 const { fileURLToPath, pathToFileURL } = getBuiltin("node:url");
-const { join, dirname, extname: pathExtname } = getBuiltin("node:path");
+const { join, dirname, extname: pathExtname, resolve: pathResolve } = getBuiltin("node:path");
 
 // Hide nub's ARGV-only V8 flags from `process.execArgv`, FIRST — before any user
 // code, and before anything here can hand the array out.
@@ -1863,6 +1863,107 @@ function installThreadpoolPolicy() {
 // should load it (no second NODE_OPTIONS token exists in that case). Absent when
 // the chainer got its own `--import` — loading it in both places would run the
 // user's entries twice.
+// ── Default-export `fetch` handler (the auto-listener) ───────────────
+// An entry whose default export is an object with a `fetch` method is served over
+// HTTP rather than merely evaluated — the handler shape Cloudflare Workers, Bun,
+// Deno (`deno serve`) and Vercel converge on, so the same file runs on all of them
+// and under `nub <file>`. The shape of the user's own module is the whole gate: a
+// file without it runs and exits byte-for-byte as it does on plain Node, which is
+// what keeps this additive.
+//
+// The launcher sets SERVE_ENTRY_ENV for a top-level `nub <file>` and `nub watch`
+// only (never `--node`, never a bin launch, never the `node` hijack), and this
+// function DELETES it before any user code runs. That delete is the whole
+// containment: a `child_process` spawn or a Worker copies `process.env` after it is
+// gone, so a server entry that forks a worker pool does not hand every worker its own
+// listener — no `worker_threads` probe needed here to tell the realms apart.
+const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
+
+function installServeEntry() {
+  if (!process.env[SERVE_ENTRY_ENV]) return;
+  delete process.env[SERVE_ENTRY_ENV];
+  // Deferred, because the entry has not been evaluated yet — the preload runs
+  // first, by construction. One `setImmediate` is enough for a CommonJS entry
+  // (`Module.runMain` is synchronous, so it has finished by the check phase); an ES
+  // module entry may still be mid-evaluation, which is why the resolution below
+  // awaits Node's own module job instead of assuming anything has landed.
+  // `.unref()` is deliberately NOT called: a synchronous script must still reach
+  // this pass, or a server whose module body does nothing asynchronous would exit
+  // before it could bind.
+  setImmediate(() => {
+    serveEntryIfHandler().catch(() => {
+      // An entry that threw has already been reported by Node as an uncaught
+      // error; re-surfacing our own view of it would double the report, and
+      // leaving this promise unhandled would itself change the exit path.
+    });
+  });
+}
+
+async function serveEntryIfHandler() {
+  const file = mainEntryPath();
+  if (!file) return;
+  const handler = fetchHandler(await entryDefaultExport(file));
+  if (!handler) return;
+  // Required only now, so an ordinary file run never loads node:http at all.
+  require("./fetch-serve.cjs").serve(handler);
+}
+
+// The entry as Node itself resolved it: `resolveMainPath` is `Module._findPath` over
+// the absolute `argv[1]` with `isMain` true, so deferring to the same call inherits
+// every main-specific behavior — extension and index probing, a directory's
+// package `main`, and `--preserve-symlinks-main` — instead of reimplementing a
+// second resolver that could name a different file than the one Node loaded.
+function mainEntryPath() {
+  const main = process.argv[1];
+  // Absent for `--eval`/`--print` and the REPL; `-` is stdin, which has no module
+  // identity to inspect.
+  if (typeof main !== "string" || main === "" || main === "-") return null;
+  try {
+    const found = module_._findPath(pathResolve(main), null, true);
+    return typeof found === "string" && found !== "" ? found : null;
+  } catch {
+    return null;
+  }
+}
+
+// A CommonJS entry is already on `process.mainModule`, fully evaluated, so its
+// exports need no module-loader round trip. Anything else — an ES module entry, or a
+// CommonJS one the ESM loader owns on the `--import` compat tier — is reached through
+// `import()`, which returns the job Node already created for that URL. So the entry
+// evaluates exactly once whichever of us gets there first, and the promise settles
+// only after the entry's own top-level await does.
+//
+// Getting there first would cost the entry its `isEntryPoint` flag, and with it
+// `import.meta.main`. It cannot happen on the fast tier, where the `--require` preload
+// is synchronous, so Node's own entry import runs in the same macrotask that scheduled
+// this callback and the check phase cannot interleave. The compat tier's `--import`
+// preload does await, but that tier is Node ≤ 22.14, which has no `import.meta.main`
+// to lose. Measured `true` on the fast tier and `undefined` on 20.19 and 22.14, which
+// is what plain Node reports on each.
+async function entryDefaultExport(file) {
+  const main = process.mainModule;
+  if (main && main.loaded && main.filename === file) return main.exports;
+  return (await import(pathToFileURL(file).href)).default;
+}
+
+// The handler object, or null when the default export is not one. A `.ts` or `.js`
+// entry that resolves as CommonJS carries `export default` as
+// `{ __esModule: true, default: … }` after transpilation, and Node's interop hands
+// that whole object over as the namespace `default` — so unwrap exactly one level of
+// it. A CommonJS entry written as `module.exports = { fetch }` needs no unwrapping
+// and is accepted as it stands.
+function fetchHandler(value) {
+  let handler = value;
+  if (isPlainish(handler) && handler.__esModule === true && isPlainish(handler.default)) {
+    handler = handler.default;
+  }
+  return isPlainish(handler) && typeof handler.fetch === "function" ? handler : null;
+}
+
+function isPlainish(value) {
+  return typeof value === "object" && value !== null;
+}
+
 function userPreloadChain() {
   try {
     const chain = JSON.parse(process.env.__NUB_RUNTIME_CONFIG || "{}").preloadChain;
@@ -1911,6 +2012,9 @@ module.exports = {
   restoreCompileCacheEnv,
   installCompiledChildProcess,
   reenableUserCompileCache,
+  installServeEntry,
+  // Exported for the unit test that asserts which default-export shapes are served.
+  fetchHandler,
   requireUserPreloadChain,
   importUserPreloadChain,
 };

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -717,6 +717,8 @@ function makeHooks(core, watchReporting, foreignLoaderFlagPresent = foreignAsync
   // `noteRuntimeV8FlagSource`. A no-op (one null check) unless the spawn layer armed
   // a flag for this Node.
   function load(url, context, nextLoad) {
+    // The fetch-handler pass may be waiting for Node to start loading the entry.
+    noteEntryLoad(url);
     return core.noteRuntimeV8FlagSource(loadInner(url, context, nextLoad));
   }
 
@@ -1884,57 +1886,154 @@ function installThreadpoolPolicy() {
 const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
 const SERVE_ENTRY_SEPARATOR = "\x1f";
 
+// The entry this process was marked to serve, from `claimServeEntry` on: the file as
+// Node resolved it, the URLs a load hook may see it under, whether a preload may
+// still follow nub's own, and the state the late pass waits on — whether a hook has
+// seen Node start loading the entry, and what to run when one does. Null in every
+// process that is not the marked application.
+let serveEntry = null;
+
+// FIRST in each preload entry, before any user code — the configured preload chain
+// included: consume the marker, so nothing the user wrote ever sees it, and resolve
+// the entry, so the hooks know which URL announces it. Arming the pass itself waits
+// for `installServeEntry`, at the very end of the preload.
+function claimServeEntry() {
+  const marker = process.env[SERVE_ENTRY_ENV];
+  if (marker === undefined) return;
+  if (!markedEntryIsThisProcess(marker)) return;
+  delete process.env[SERVE_ENTRY_ENV];
+  const file = mainEntryPath();
+  if (!file) return;
+  serveEntry = {
+    file,
+    urls: entryUrls(file),
+    mayFollow: anotherPreloadMayFollow(),
+    taken: false,
+    loadSeen: false,
+    onLoad: null,
+    channel: null,
+  };
+}
+
 // NEVER START THE ENTRY OURSELVES BEFORE NODE WOULD HAVE. The inspection below can
 // reach the entry through `import()`, and an `import()` that lands while a preload is
 // still pending EVALUATES THE ENTRY EARLY — ahead of the very preloads that exist to
 // set its realm up. That is not theoretical: a single `setImmediate` here put the
 // entry between two chained preload entries on Node 18.19 and 20.11, which is exactly
-// the additivity guarantee this feature is supposed to preserve. So the pass is armed
-// on two triggers, neither of which can get there first:
+// the additivity guarantee this feature is supposed to preserve. So the pass runs on
+// three triggers, none of which can get there first:
 //
 //   1. A `setImmediate`, which reads a CommonJS entry straight off `process.mainModule`
 //      and imports NOTHING. `Module.runMain` is synchronous, so a CommonJS entry has
 //      finished by the check phase. It may only `import()` when no preload can still
-//      follow nub's own — see `anotherPreloadMayFollow`.
-//   2. `beforeExit`, which fires when the loop drains, and therefore strictly after
-//      every preload AND the entry have run. Importing is unconditionally safe here
-//      because there is nothing left to front-run, and a `beforeExit` listener may do
-//      async work, which is what keeps the process alive once a listener binds.
+//      follow nub's own (`anotherPreloadMayFollow`), or when a hook has already seen
+//      Node start loading the entry.
+//   2. The load hook seeing the entry (`noteEntryLoad`): Node imports the entry only
+//      after awaiting the last `--import`, so by then every preload has run and an
+//      `import()` can only join the job Node already made. This fires whatever the
+//      loop is doing, which is what serves a handler whose preload or module body
+//      holds a timer, a socket or a Worker for good.
+//   3. `beforeExit`, for the hook configuration in which nub's hooks never see the
+//      entry at all. It fires only once the loop drains, so it is the last resort
+//      and never the only one.
 //
-// Between them the only entry that goes unserved is one reached through `import()`
-// whose module body keeps the loop busy forever WHILE a foreign preload token exists.
-// Declining to serve is the right side to fail on: reordering a user's preloads is a
-// correctness break, and not binding a port is not.
+// Declining to serve remains the right side to fail on where none of the three can
+// fire: reordering a user's preloads is a correctness break, and not binding a port
+// is not.
 function installServeEntry() {
-  const marker = process.env[SERVE_ENTRY_ENV];
-  if (marker === undefined) return;
-  if (!markedEntryIsThisProcess(marker)) return;
-  delete process.env[SERVE_ENTRY_ENV];
+  const entry = serveEntry;
+  if (entry === null) return;
   const report = (err) => {
     // A throwing entry is handled inside, so nothing here is expected to reject and
     // anything that does is nub's own defect, named as such. Leaving the promise
     // unhandled instead would change the process's exit path.
     process.stderr.write(`nub: could not inspect the entry for a fetch handler: ${err}\n`);
   };
-  const claim = { taken: false };
+  // Whichever late trigger fires, the other is withdrawn with it, so the process
+  // carries neither once the entry has been inspected.
+  const late = () => {
+    process.removeListener("beforeExit", late);
+    return serveEntryIfHandler(entry, true).then(() => closeEntryChannel(entry)).catch(report);
+  };
   // Not `.unref()`d: a synchronous script must still reach this pass, or a server
   // whose module body does nothing asynchronous would exit before binding.
   setImmediate(() => {
-    serveEntryIfHandler(claim, !anotherPreloadMayFollow())
+    serveEntryIfHandler(entry, entry.loadSeen || !entry.mayFollow)
       .then((deferred) => {
-        // The `beforeExit` trigger is registered ONLY when the pass above declined
-        // for want of permission to import — never on an ordinary run. A listener
-        // added up front is observable to the user's own code
-        // (`process.listenerCount("beforeExit")` reads 1 where plain Node reads 0),
-        // and an unconditional one made every `nub <file>` run carry it.
-        if (deferred) {
-          process.once("beforeExit", () => {
-            serveEntryIfHandler(claim, true).catch(report);
-          });
+        if (!deferred) {
+          closeEntryChannel(entry);
+          return;
         }
+        // Registered ONLY when the pass above declined for want of permission to
+        // import — never on an ordinary run. A `beforeExit` listener added up front
+        // is observable to the user's own code (`process.listenerCount("beforeExit")`
+        // reads 1 where plain Node reads 0), and an unconditional one made every
+        // `nub <file>` run carry it.
+        entry.onLoad = late;
+        if (entry.loadSeen) fireEntryLoad(entry);
+        // The worker's signal has to reach a live loop, so the port holds the process
+        // open until it does; `closeEntryChannel` lets go afterwards.
+        if (entry.channel !== null) entry.channel.port1.ref();
+        process.once("beforeExit", late);
       })
       .catch(report);
   });
+}
+
+// The URLs a load hook may see the entry under. Node's ESM resolver hands the hook
+// the realpath unless symlinks are preserved, and `_findPath` has usually resolved it
+// already — so both spellings are watched rather than guessing which one applies.
+function entryUrls(file) {
+  const urls = new Set([pathToFileURL(file).href]);
+  try {
+    urls.add(pathToFileURL(getBuiltin("node:fs").realpathSync(file)).href);
+  } catch { /* unreadable — the unresolved spelling still matches Node's own */ }
+  return urls;
+}
+
+// A load hook saw Node start loading `url`. Called from the fast tier's synchronous
+// hook for every load, and from the compat tier's loader worker over the channel
+// `loaderWorkerOptions` hands it. Free in every process but the marked application.
+function noteEntryLoad(url) {
+  const entry = serveEntry;
+  if (entry === null || entry.loadSeen || !entry.urls.has(url)) return;
+  entry.loadSeen = true;
+  fireEntryLoad(entry);
+}
+
+function fireEntryLoad(entry) {
+  const onLoad = entry.onLoad;
+  if (onLoad === null) return;
+  entry.onLoad = null;
+  // Out of the hook's own stack: the sync hook runs INSIDE Node's load of the entry,
+  // and an `import()` issued from there would re-enter the loader.
+  setImmediate(onLoad);
+}
+
+// For `registerLoaderWorker`, on the tiers whose hooks run in a loader worker: the
+// port that worker announces the entry's load on, or nothing. Created only when the
+// pass will have to wait for that announcement, because the port is a handle the
+// process carries until the entry loads and an ordinary run should carry nothing.
+function loaderWorkerOptions() {
+  const entry = serveEntry;
+  if (entry === null || !entry.mayFollow) return undefined;
+  const { MessageChannel } = getBuiltin("node:worker_threads");
+  const channel = new MessageChannel();
+  channel.port1.on("message", noteEntryLoad);
+  // Referenced only once the pass is actually waiting — see `installServeEntry`.
+  channel.port1.unref();
+  entry.channel = channel;
+  return {
+    data: { entryLoad: { port: channel.port2, urls: [...entry.urls] } },
+    transferList: [channel.port2],
+  };
+}
+
+function closeEntryChannel(entry) {
+  const channel = entry.channel;
+  if (channel === null) return;
+  entry.channel = null;
+  channel.port1.close();
 }
 
 // Is this process the application the launcher marked, or a wrapper it put in
@@ -1989,26 +2088,33 @@ function anotherPreloadMayFollow() {
 
 // Serve the entry if its default export is a handler. Resolves TRUE when it declined
 // only because it may not import yet, which is the caller's signal to arm the late
-// trigger. `claim` is shared by both triggers: whichever gets a usable namespace takes
-// it SYNCHRONOUSLY, before any await, so the two can never both bind a listener.
-async function serveEntryIfHandler(claim, mayImport) {
-  if (claim.taken) return false;
-  const file = mainEntryPath();
-  if (!file) {
-    claim.taken = true;
-    return false;
-  }
+// triggers. `entry.taken` is shared by every trigger: whichever gets a usable
+// namespace takes it SYNCHRONOUSLY, before any await, so no two can bind a listener.
+//
+// A CommonJS entry is already on `process.mainModule`, fully evaluated, so its
+// exports need no module-loader round trip. Anything else — an ES module entry, or a
+// CommonJS one the ESM loader owns on the `--import` compat tier — is reached through
+// `import()`, which returns the job Node already created for that URL. So the entry
+// evaluates exactly once whichever of us gets there first, and the promise settles
+// only after the entry's own top-level await does. Getting there first would cost the
+// entry its `isEntryPoint` flag, and with it `import.meta.main`; on the fast tier the
+// `--require` preload is synchronous, so Node's own import runs in the same macrotask
+// that scheduled the pass, and the compat tier is Node ≤ 22.14, which has no
+// `import.meta.main` to lose. Measured `true` on the fast tier and `undefined` on
+// 20.19 and 22.14, which is what plain Node reports on each.
+async function serveEntryIfHandler(entry, mayImport) {
+  if (entry.taken) return false;
   const main = process.mainModule;
-  if (main && main.loaded && main.filename === file) {
-    claim.taken = true;
+  if (main && main.loaded && main.filename === entry.file) {
+    entry.taken = true;
     serveIfHandler(main.exports);
     return false;
   }
   if (!mayImport) return true;
-  claim.taken = true;
+  entry.taken = true;
   let ns;
   try {
-    ns = await import(pathToFileURL(file).href);
+    ns = await import(pathToFileURL(entry.file).href);
   } catch {
     // The entry threw. Node has already reported that as an uncaught error, and this
     // is the same failure observed a second time, so it is dropped rather than
@@ -2042,26 +2148,6 @@ function mainEntryPath() {
   } catch {
     return null;
   }
-}
-
-// A CommonJS entry is already on `process.mainModule`, fully evaluated, so its
-// exports need no module-loader round trip. Anything else — an ES module entry, or a
-// CommonJS one the ESM loader owns on the `--import` compat tier — is reached through
-// `import()`, which returns the job Node already created for that URL. So the entry
-// evaluates exactly once whichever of us gets there first, and the promise settles
-// only after the entry's own top-level await does.
-//
-// Getting there first would cost the entry its `isEntryPoint` flag, and with it
-// `import.meta.main`. It cannot happen on the fast tier, where the `--require` preload
-// is synchronous, so Node's own entry import runs in the same macrotask that scheduled
-// this callback and the check phase cannot interleave. The compat tier's `--import`
-// preload does await, but that tier is Node ≤ 22.14, which has no `import.meta.main`
-// to lose. Measured `true` on the fast tier and `undefined` on 20.19 and 22.14, which
-// is what plain Node reports on each.
-async function entryDefaultExport(file) {
-  const main = process.mainModule;
-  if (main && main.loaded && main.filename === file) return main.exports;
-  return (await import(pathToFileURL(file).href)).default;
 }
 
 // The handler object, or null when the default export is not one. A `.ts` or `.js`
@@ -2130,6 +2216,8 @@ module.exports = {
   restoreCompileCacheEnv,
   installCompiledChildProcess,
   reenableUserCompileCache,
+  claimServeEntry,
+  loaderWorkerOptions,
   installServeEntry,
   // Exported for the unit test that asserts which default-export shapes are served.
   fetchHandler,

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -1880,11 +1880,10 @@ function installThreadpoolPolicy() {
 // it is gone, so a server entry that forks a worker pool does not hand every worker
 // its own listener — no `worker_threads` probe needed here to tell the realms apart.
 //
-// Its value is the launcher's argv, tokens joined by SERVE_ENTRY_SEPARATOR, and
-// that is what makes "the application's preload" a process this code can identify:
-// see `markedEntryIsThisProcess`.
+// Its value is the launcher's argv as a JSON array, and that is what makes "the
+// application's preload" a process this code can identify: see
+// `markedEntryIsThisProcess`.
 const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
-const SERVE_ENTRY_SEPARATOR = "\x1f";
 
 // The entry this process was marked to serve, from `claimServeEntry` on: the file as
 // Node resolved it, the URLs a load hook may see it under, whether a preload may
@@ -2068,13 +2067,31 @@ function closeEntryChannel(entry) {
 function markedEntryIsThisProcess(marker) {
   const main = process.argv[1];
   if (typeof main !== "string") return true;
-  const tokens = marker.split(SERVE_ENTRY_SEPARATOR);
+  const tokens = markerTokens(marker);
+  if (tokens === null) return false;
   const rest = process.argv.slice(2);
   const at = tokens.length - rest.length - 1;
   if (at < 0) return false;
   const entry = tokens[at];
   if (entry === "" || (entry !== main && pathResolve(entry) !== main)) return false;
   return rest.every((arg, i) => arg === tokens[at + 1 + i]);
+}
+
+// The launcher's argv out of the marker, or null for a value nub did not write. A
+// JSON array rather than a joined string because an argument may hold any byte but
+// NUL: ASCII unit separator was the join once, and one inside an argument split it
+// in two and moved the entry off its position. A value that does not parse is left
+// alone and claims nothing.
+function markerTokens(marker) {
+  let tokens;
+  try {
+    tokens = JSON.parse(marker);
+  } catch {
+    return null;
+  }
+  return Array.isArray(tokens) && tokens.every((token) => typeof token === "string")
+    ? tokens
+    : null;
 }
 
 // Could a preload still run after nub's own? True whenever an `--import`/`--loader`

--- a/runtime/preload-common.cjs
+++ b/runtime/preload-common.cjs
@@ -648,6 +648,9 @@ function makeHooks(core, watchReporting, foreignLoaderFlagPresent = foreignAsync
   installUserAsyncLoaderDetector();
 
   function resolve(specifier, context, nextResolve) {
+    // The fetch-handler pass tells the entry's own load from a preload's import of
+    // the same file by Node resolving it first as the main, with no parent.
+    noteEntryResolve(specifier, context);
     const r = core.resolveSpec(specifier, context.parentURL);
     if (r) return r;
     // Yarn PnP (ESM): PnP doesn't patch the ESM loader, so `import` of a PnP dep must
@@ -1888,8 +1891,9 @@ const SERVE_ENTRY_ENV = "__NUB_SERVE_ENTRY";
 // The entry this process was marked to serve, from `claimServeEntry` on: the file as
 // Node resolved it, the URLs a load hook may see it under, whether a preload may
 // still follow nub's own, and the state the late pass waits on — whether a hook has
-// seen Node start loading the entry, the URL it saw it under, and what to run when
-// one does. Null in every process that is not the marked application.
+// seen Node resolve the entry as its main and then start loading it, the URL it saw
+// it loaded under, and what to run when one does. Null in every process that is not
+// the marked application.
 let serveEntry = null;
 
 // FIRST in each preload entry, before any user code — the configured preload chain
@@ -1908,6 +1912,7 @@ function claimServeEntry() {
     urls: entryUrls(file),
     mayFollow: anotherPreloadMayFollow(),
     taken: false,
+    mainResolved: false,
     loadSeen: false,
     loadUrl: null,
     onLoad: null,
@@ -1999,12 +2004,26 @@ function entryUrls(file) {
   return urls;
 }
 
+// A resolve hook saw Node resolve `specifier` with no parent, which is how Node
+// imports its main entry and nothing else — a preload's `import()` of the same file
+// carries the preload as its parent. Only a load AFTER this can be the entry's own:
+// a preload that imports `./entry.mjs?warm` ahead of the program would otherwise
+// be taken for it, and the pass would serve that module's handler while Node went
+// on to evaluate the real entry as a second one. Called from the fast tier's
+// synchronous hook; the compat tier's loader worker keeps the same note itself.
+function noteEntryResolve(specifier, context) {
+  const entry = serveEntry;
+  if (entry === null || entry.mainResolved || context.parentURL !== undefined) return;
+  if (entry.urls.has(withoutQuery(String(specifier)))) entry.mainResolved = true;
+}
+
 // A load hook saw Node start loading `url`. Called from the fast tier's synchronous
 // hook for every load, and from the compat tier's loader worker over the channel
 // `loaderWorkerOptions` hands it. Free in every process but the marked application.
 function noteEntryLoad(url) {
   const entry = serveEntry;
-  if (entry === null || entry.loadSeen || !entry.urls.has(withoutQuery(url))) return;
+  if (entry === null || !entry.mainResolved || entry.loadSeen) return;
+  if (!entry.urls.has(withoutQuery(url))) return;
   entry.loadSeen = true;
   entry.loadUrl = url;
   fireEntryLoad(entry);
@@ -2033,7 +2052,12 @@ function loaderWorkerOptions() {
   if (entry === null || !entry.mayFollow) return undefined;
   const { MessageChannel } = getBuiltin("node:worker_threads");
   const channel = new MessageChannel();
-  channel.port1.on("message", noteEntryLoad);
+  // The worker keeps the main-resolve note itself and announces only a load after
+  // it (preload-async-hooks.mjs), so its word stands in for `noteEntryResolve` here.
+  channel.port1.on("message", (url) => {
+    entry.mainResolved = true;
+    noteEntryLoad(url);
+  });
   // Never referenced, so an announcement that never comes cannot hold the process
   // open — see the triggers above `installServeEntry`.
   channel.port1.unref();

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -81,6 +81,10 @@ common.installVersionMarker();
 // Strip nub's own UV_THREADPOOL_SIZE so children get Node's default, and demote
 // the workers beyond Node's four on Linux. Tier-independent, like the marker.
 common.installThreadpoolPolicy();
+// Consume the launcher's fetch-handler marker BEFORE any user code — the configured
+// preload chain below included — and note which entry it names. Arming the pass
+// itself waits for the end of this file (`installServeEntry`).
+common.claimServeEntry();
 
 // `--no-experimental-require-module` disables require(esm) globally, so the
 // transform-core require below (and the worker/locks ESM side-effect modules)
@@ -216,7 +220,11 @@ if (hasRegisterHooks && !requireEsmDisabled && !forceAsyncTier) {
   // not leaked onto the user's stderr — on every entry above nub is forced onto
   // module.register (require(esm) off, foreign-loader composition, or registerHooks
   // absent outright), so the user has no action to take. See registerLoaderWorker.
-  common.registerLoaderWorker("./preload-async-hooks.mjs", pathToFileURL(__filename).href);
+  common.registerLoaderWorker(
+    "./preload-async-hooks.mjs",
+    pathToFileURL(__filename).href,
+    common.loaderWorkerOptions(),
+  );
 
   // Entry 3 only. `module.register` is ESM-loader-only, so without this a
   // `require('./x.ts')` on 23.0–23.4 reaches Node raw and dies on the first type
@@ -273,9 +281,10 @@ if (core && core.sweepDue()) {
 // ── Default-export `fetch` handler (BOTH branches above) ────────────
 // Arms the deferred pass that serves an entry whose default export is a `fetch`
 // handler. Tier-independent — the same call sits in preload.mjs — and a no-op
-// unless the launcher marked this process a top-level file run. Placed after the
-// tier branches so the shape check runs on either, and after the eviction block for
-// the same reason it is: nothing here may touch the bootstrap module list.
+// unless `claimServeEntry` above found this process marked as a top-level file
+// run. Placed after the tier branches so the shape check runs on either, and after
+// the eviction block for the same reason it is: nothing here may touch the
+// bootstrap module list.
 common.installServeEntry();
 
 // ── Lazy ESM-side-effect polyfills (R7) ─────────────────────────────

--- a/runtime/preload.cjs
+++ b/runtime/preload.cjs
@@ -270,6 +270,14 @@ if (core && core.sweepDue()) {
   });
 }
 
+// ── Default-export `fetch` handler (BOTH branches above) ────────────
+// Arms the deferred pass that serves an entry whose default export is a `fetch`
+// handler. Tier-independent — the same call sits in preload.mjs — and a no-op
+// unless the launcher marked this process a top-level file run. Placed after the
+// tier branches so the shape check runs on either, and after the eviction block for
+// the same reason it is: nothing here may touch the bootstrap module list.
+common.installServeEntry();
+
 // ── Lazy ESM-side-effect polyfills (R7) ─────────────────────────────
 // The two ESM side-effect polyfills — the browser-shape Worker global
 // (worker-polyfill.mjs) and Web Locks (navigator-locks.mjs) — were previously

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -52,6 +52,11 @@ const { installSyncPolyfills } = __require("./polyfills.cjs");
 // Tier-independent — same call in the fast entry (preload.cjs).
 common.installVersionMarker();
 common.installThreadpoolPolicy();
+// Consume the launcher's fetch-handler marker BEFORE any user code — the configured
+// preload chain below included — and note which entry it names, so the loader
+// worker registered below can announce that entry's load. Arming the pass itself
+// waits for the end of this file (`installServeEntry`).
+common.claimServeEntry();
 
 // ── Tier detection ──────────────────────────────────────────────────
 // This `.mjs` preload should only ever be `--import`ed for the compat tier (the
@@ -98,7 +103,11 @@ if (__isFastTier) {
   // On the compat tier proper (18.19–22.14, and 23.0–23.4) registerHooks doesn't
   // exist, so the loader-worker is the only hook surface; the user has no action
   // to take.
-  common.registerLoaderWorker("./preload-async-hooks.mjs", import.meta.url);
+  common.registerLoaderWorker(
+    "./preload-async-hooks.mjs",
+    import.meta.url,
+    common.loaderWorkerOptions(),
+  );
   // (The main-thread require() shim's module-format + decorator detection is a
   // synchronous native addon call now — no parser warm-up; the old
   // `await core.ensureParser()` for the ESM-only oxc-parser is gone.)
@@ -191,5 +200,6 @@ await common.importUserPreloadChain();
 // to the event loop — so arming before it put the check phase BETWEEN two of the
 // user's preload entries, where the pass imported the entry and ran it ahead of them.
 // Arming here means every preload nub carries has already run. (A preload on its own
-// `--import` token can still follow; `installServeEntry` detects that case itself.)
+// `--import` token can still follow; `claimServeEntry` detected that case up front,
+// and the pass then waits for the loader worker to announce the entry's load.)
 common.installServeEntry();

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -174,6 +174,12 @@ if (core.sweepDue()) {
   });
 }
 
+// ── Default-export `fetch` handler ──────────────────────────────────
+// Arms the deferred pass that serves an entry whose default export is a `fetch`
+// handler. Tier-independent — the same call sits in preload.cjs — and a no-op
+// unless the launcher marked this process a top-level file run.
+common.installServeEntry();
+
 // ── User preloads (`nub.jsonc` `preload`) ───────────────────────────
 // LAST, so the user's entries observe a fully-augmented realm — hooks installed,
 // polyfills in place. Awaited, so a top-level `await` inside an entry settles before

--- a/runtime/preload.mjs
+++ b/runtime/preload.mjs
@@ -174,12 +174,6 @@ if (core.sweepDue()) {
   });
 }
 
-// ── Default-export `fetch` handler ──────────────────────────────────
-// Arms the deferred pass that serves an entry whose default export is a `fetch`
-// handler. Tier-independent — the same call sits in preload.cjs — and a no-op
-// unless the launcher marked this process a top-level file run.
-common.installServeEntry();
-
 // ── User preloads (`nub.jsonc` `preload`) ───────────────────────────
 // LAST, so the user's entries observe a fully-augmented realm — hooks installed,
 // polyfills in place. Awaited, so a top-level `await` inside an entry settles before
@@ -187,3 +181,15 @@ common.installServeEntry();
 // A no-op unless the spawn path put the chainer on nub's own preload rather than its
 // own `--import`. See importUserPreloadChain.
 await common.importUserPreloadChain();
+
+// ── Default-export `fetch` handler ──────────────────────────────────
+// Arms the deferred pass that serves an entry whose default export is a `fetch`
+// handler. Tier-independent — the same call sits in preload.cjs.
+//
+// LAST, AFTER the awaited preload chain above, and that order is load-bearing. The
+// pass arms a `setImmediate`, and the chainer's own `await import()` per entry yields
+// to the event loop — so arming before it put the check phase BETWEEN two of the
+// user's preload entries, where the pass imported the entry and ran it ahead of them.
+// Arming here means every preload nub carries has already run. (A preload on its own
+// `--import` token can still follow; `installServeEntry` detects that case itself.)
+common.installServeEntry();

--- a/scripts/build-loader-npm.mjs
+++ b/scripts/build-loader-npm.mjs
@@ -35,6 +35,11 @@ const RUNTIME_FILES = [
   "pnp-util.cjs",
   "floor-builtin.mjs",
   "cache-evict.mjs",
+  // Reachable only through preload-common.cjs's lazy require, which the
+  // launcher-only serve signal gates — but it IS in the relative-import graph,
+  // and the closure rule above is what keeps a future reachability change from
+  // shipping a tarball that resolves to nothing.
+  "fetch-serve.cjs",
 ];
 
 const args = process.argv.slice(2);

--- a/site/content/docs/compile.mdx
+++ b/site/content/docs/compile.mdx
@@ -947,6 +947,8 @@ A compiled Windows executable is not Authenticode-signed. Windows runs unsigned 
 
 The embedded or provisioned runtime is official, unpatched Node. The launcher starts it with a fixed internal CommonJS bootstrap, version-appropriate flags, and the bundled preamble. The inherited `NODE_OPTIONS` value is passed to Node unchanged, so supported Node flags keep their normal behavior.
 
+An artifact reproduces what `nub <file>` does rather than what `node <file>` does, so an entry whose default export has a `fetch` method is [served over HTTP](/docs/runtime/fetch-handler) by the executable too.
+
 ### Process identity
 
 The application sees the outer artifact as its executable while retaining Node's native process name:

--- a/site/content/docs/runtime/fetch-handler.mdx
+++ b/site/content/docs/runtime/fetch-handler.mdx
@@ -102,6 +102,15 @@ $ nub watch server.ts
 Listening on http://localhost:3000
 ```
 
+## Compiled executables
+
+[`nub compile`](/docs/compile) carries the handler into the executable it builds, so the compiled server binds a port on launch the way the source file does:
+
+```console
+$ ./server
+Listening on http://localhost:3000
+```
+
 ## Plain Node
 
 Passing [`--node`](/docs/node) runs the file on stock Node, where a default-exported `fetch` means nothing and the process exits once the module has evaluated.

--- a/site/content/docs/runtime/fetch-handler.mdx
+++ b/site/content/docs/runtime/fetch-handler.mdx
@@ -1,0 +1,113 @@
+---
+title: Fetch handler
+description: A default-exported object with a fetch method is served over HTTP. It is the same handler Cloudflare Workers, Bun, Deno and Vercel accept, so one file runs on all of them and on Nub.
+unpublished: true
+---
+
+Export an object with a `fetch` method and Nub serves it:
+
+```ts
+// server.ts
+export default {
+  fetch(request: Request): Response {
+    return new Response(`hello from ${new URL(request.url).pathname}`);
+  },
+};
+```
+
+```console
+$ nub server.ts
+Listening on http://localhost:3000
+```
+
+The handler takes a WHATWG [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and returns a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response), or a promise for one. Nub binds a port, converts each inbound request, and writes the response back.
+
+## Portability
+
+Cloudflare Workers, Bun, Deno and Vercel all read this shape, so the file above runs unmodified on any of them:
+
+```sh
+nub server.ts          # Nub
+bun server.ts          # Bun
+deno serve server.ts   # Deno
+wrangler deploy        # Cloudflare Workers
+```
+
+Each of those runtimes passes a second argument of its own — bindings on Workers, the server on Bun, connection info on Deno. Nub passes one argument, so a handler that reads only the request is the portable form.
+
+## What Nub serves
+
+The shape of the default export is the whole trigger. A file whose default export is an object with a callable `fetch` becomes a server; every other file runs and exits the way `node` runs it.
+
+```ts
+export default { fetch() { … } };        // served
+export default { name: "config" };       // ordinary script
+export function handler() { … }          // ordinary script
+```
+
+CommonJS works through the same check, so a `.ts` file in a package without `"type": "module"` is served too:
+
+```js
+// server.cjs
+module.exports = {
+  fetch() {
+    return new Response("hello");
+  },
+};
+```
+
+## `port`
+
+Nub reads the port from the first of these that is set:
+
+- `PORT` in the environment
+- `port` on the default export
+- 3000
+
+```ts
+export default {
+  port: 8080,
+  fetch() {
+    return new Response("hello");
+  },
+};
+```
+
+```console
+$ PORT=4000 nub server.ts
+Listening on http://localhost:4000
+```
+
+Setting `PORT=0` picks any free port, which is what a test harness wants. A port already in use is fatal.
+
+## `hostname`
+
+The bind address comes from the first of these that is set:
+
+- `HOST` in the environment
+- `hostname` on the default export
+- every interface
+
+```console
+$ HOST=127.0.0.1 nub server.ts
+Listening on http://127.0.0.1:3000
+```
+
+## Watch mode
+
+Running the file under [`nub watch`](/docs/watch) restarts the server on every edit:
+
+```console
+$ nub watch server.ts
+Listening on http://localhost:3000
+```
+
+## Plain Node
+
+Passing [`--node`](/docs/node) runs the file on stock Node, where a default-exported `fetch` means nothing and the process exits once the module has evaluated.
+
+To serve the same file without Nub, install an adapter that reads the export and binds the listener. [`srvx`](https://www.npmjs.com/package/srvx) and [`@hono/node-server`](https://www.npmjs.com/package/@hono/node-server) both do, and neither asks you to change the handler.
+
+```sh
+npx srvx ./server.ts
+```

--- a/site/content/docs/runtime/meta.json
+++ b/site/content/docs/runtime/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Runtime",
   "defaultOpen": false,
-  "pages": ["index", "typescript", "jsx", "decorators", "resolution", "env", "varlock", "loaders", "modern-apis", "workers", "web-storage", "threadpool", "debugging"]
+  "pages": ["index", "typescript", "jsx", "decorators", "resolution", "fetch-handler", "env", "varlock", "loaders", "modern-apis", "workers", "web-storage", "threadpool", "debugging"]
 }

--- a/tests/compile-augmentation/fixtures/a-fetch-handler-cjs.cjs
+++ b/tests/compile-augmentation/fixtures/a-fetch-handler-cjs.cjs
@@ -1,0 +1,34 @@
+// The CommonJS spelling of a-fetch-handler.mjs: `module.exports` is the handler,
+// and the bundler's interop has to hand it to the program root as `default` for
+// the artifact to serve it. A CommonJS entry cannot await a port probe, so the
+// port is derived from the pid — unique enough for a harness that runs its
+// fixtures one at a time — and cleared of `PORT` for the same reason as the ESM
+// fixture.
+delete process.env.PORT;
+
+const port = 40000 + (process.pid % 1000);
+const deadline = Date.now() + 3000;
+const report = (line) => process.stdout.write(`${line}\n`, () => process.exit(0));
+(async () => {
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      report(`served:${res.status}:${await res.text()}`);
+      return;
+    } catch {
+      if (Date.now() > deadline) {
+        report("served:none");
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+})();
+
+module.exports = {
+  port,
+  hostname: "127.0.0.1",
+  fetch() {
+    return new Response("hello from commonjs");
+  },
+};

--- a/tests/compile-augmentation/fixtures/a-fetch-handler.mjs
+++ b/tests/compile-augmentation/fixtures/a-fetch-handler.mjs
@@ -1,0 +1,48 @@
+// A default-exported `fetch` handler is served by `nub <file>`, and the artifact
+// has to serve it too — a server is the program most worth compiling. The fixture
+// binds on a port it picked itself, requests its own root, prints what came back
+// and exits. Plain Node evaluates the module and finds nothing listening, which is
+// what makes this row discriminating.
+//
+// Polls rather than sleeps, so a slow runner cannot turn a working server into a
+// wrong answer; the deadline only bounds the plain-Node row. `PORT` is cleared
+// because it outranks the export's own port, and a runner that happened to set it
+// would move the listener away from where the probe looks.
+import { createServer } from "node:net";
+
+delete process.env.PORT;
+
+const port = await new Promise((resolve, reject) => {
+  const probe = createServer();
+  probe.once("error", reject);
+  probe.listen(0, "127.0.0.1", () => {
+    const { port } = probe.address();
+    probe.close(() => resolve(port));
+  });
+});
+
+const deadline = Date.now() + 3000;
+const report = (line) => process.stdout.write(`${line}\n`, () => process.exit(0));
+(async () => {
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      report(`served:${res.status}:${await res.text()}`);
+      return;
+    } catch {
+      if (Date.now() > deadline) {
+        report("served:none");
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+})();
+
+export default {
+  port,
+  hostname: "127.0.0.1",
+  fetch() {
+    return new Response("hello from the handler");
+  },
+};

--- a/tests/fixtures/entry-url-rewrite/holds.mjs
+++ b/tests/fixtures/entry-url-rewrite/holds.mjs
@@ -2,6 +2,6 @@ console.log(`holds:${new URL(import.meta.url).search}`);
 setInterval(() => {}, 1000);
 export default {
   fetch() {
-    return new Response("held");
+    return new Response(`held:${new URL(import.meta.url).search}`);
   },
 };

--- a/tests/fixtures/entry-url-rewrite/holds.mjs
+++ b/tests/fixtures/entry-url-rewrite/holds.mjs
@@ -1,0 +1,7 @@
+console.log(`holds:${new URL(import.meta.url).search}`);
+setInterval(() => {}, 1000);
+export default {
+  fetch() {
+    return new Response("held");
+  },
+};

--- a/tests/fixtures/entry-url-rewrite/package.json
+++ b/tests/fixtures/entry-url-rewrite/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "entry-url-rewrite-fixture",
+  "private": true
+}

--- a/tests/fixtures/entry-url-rewrite/plain.mjs
+++ b/tests/fixtures/entry-url-rewrite/plain.mjs
@@ -1,0 +1,1 @@
+console.log(`plain:${new URL(import.meta.url).search}`);

--- a/tests/fixtures/entry-url-rewrite/rewrite.mjs
+++ b/tests/fixtures/entry-url-rewrite/rewrite.mjs
@@ -1,6 +1,8 @@
 // A resolve hook that hands the entry a URL nub's own hooks never track: a
-// cache-busting query, the shape a hot-reload loader adds. Scoped to the entry so
-// nothing else in the process is evaluated a second time under a fresh URL.
+// cache-busting query, the shape a hot-reload loader adds. Keyed on the entry
+// having no parent — Node's own import of it is the only resolve with none — so a
+// later import of the same file from anywhere else is left alone, which is what
+// makes a second evaluation of the entry observable.
 import { register } from "node:module";
 
 register(
@@ -8,7 +10,7 @@ register(
     encodeURIComponent(`
 export async function resolve(specifier, context, next) {
   const resolved = await next(specifier, context);
-  if (resolved.url.endsWith("/plain.mjs")) resolved.url += "?v=1";
+  if (context.parentURL === undefined) resolved.url += "?v=1";
   return resolved;
 }
 `),

--- a/tests/fixtures/entry-url-rewrite/rewrite.mjs
+++ b/tests/fixtures/entry-url-rewrite/rewrite.mjs
@@ -1,0 +1,15 @@
+// A resolve hook that hands the entry a URL nub's own hooks never track: a
+// cache-busting query, the shape a hot-reload loader adds. Scoped to the entry so
+// nothing else in the process is evaluated a second time under a fresh URL.
+import { register } from "node:module";
+
+register(
+  "data:text/javascript," +
+    encodeURIComponent(`
+export async function resolve(specifier, context, next) {
+  const resolved = await next(specifier, context);
+  if (resolved.url.endsWith("/plain.mjs")) resolved.url += "?v=1";
+  return resolved;
+}
+`),
+);

--- a/tests/fixtures/entry-url-rewrite/warm.mjs
+++ b/tests/fixtures/entry-url-rewrite/warm.mjs
@@ -1,0 +1,3 @@
+// A preload that imports the entry ahead of the program, under a query of its own:
+// a second module, evaluated first, whose handler is not the one to serve.
+await import("./holds.mjs?warm");

--- a/tests/fixtures/esm-preload-await/main.mjs
+++ b/tests/fixtures/esm-preload-await/main.mjs
@@ -1,0 +1,1 @@
+console.log("main:done");

--- a/tests/fixtures/esm-preload-await/nub.jsonc
+++ b/tests/fixtures/esm-preload-await/nub.jsonc
@@ -1,0 +1,5 @@
+{
+  // An ESM preload whose top-level `await` crosses an event-loop turn: the entry
+  // must not start until it has settled, on either tier.
+  "preload": ["./pre.mjs"]
+}

--- a/tests/fixtures/esm-preload-await/package.json
+++ b/tests/fixtures/esm-preload-await/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "esm-preload-await-fixture",
+  "private": true
+}

--- a/tests/fixtures/esm-preload-await/pre.mjs
+++ b/tests/fixtures/esm-preload-await/pre.mjs
@@ -1,0 +1,6 @@
+// The await settles on a timer rather than a microtask: a macrotask turn is what
+// lets a pass armed too early in nub's own preload reach the entry ahead of this
+// file. One line each side of the await, so where the entry landed is visible.
+console.log("preload:start");
+await new Promise((resolve) => setTimeout(resolve, 30));
+console.log("preload:done");

--- a/tests/fixtures/fetch-handler/README.md
+++ b/tests/fixtures/fetch-handler/README.md
@@ -1,0 +1,5 @@
+# `fetch`-handler fixtures
+
+Entries for the default-export `fetch` handler (`crates/nub-cli/tests/fetch_handler.rs`). Each one is written the way a user would write it, so a fixture doubles as the smallest example of the shape it covers.
+
+Every served fixture is launched with `PORT=0` by the test, which makes the kernel pick a free port; the test reads the chosen one off the `Listening on …` line. So nothing here hardcodes a port, and the suite is safe to run in parallel with itself.

--- a/tests/fixtures/fetch-handler/configured.mjs
+++ b/tests/fixtures/fetch-handler/configured.mjs
@@ -1,0 +1,11 @@
+// `port` and `hostname` on the export are the two option keys the handler honors.
+// `PORT` and `HOST` in the environment outrank both.
+export default {
+  port: 41999,
+  // 127.0.0.1 rather than localhost, so a `HOST` that says `localhost` is
+  // distinguishable in the reported URL even though both name the same interface.
+  hostname: "127.0.0.1",
+  fetch() {
+    return new Response("configured");
+  },
+};

--- a/tests/fixtures/fetch-handler/holds-loop.mjs
+++ b/tests/fixtures/fetch-handler/holds-loop.mjs
@@ -1,0 +1,9 @@
+// A handler whose module body keeps the event loop alive for good, so a detection
+// pass that waited for the loop to drain would never run.
+setInterval(() => {}, 1000);
+
+export default {
+  fetch() {
+    return new Response("holds the loop");
+  },
+};

--- a/tests/fixtures/fetch-handler/no-fetch.mjs
+++ b/tests/fixtures/fetch-handler/no-fetch.mjs
@@ -1,0 +1,3 @@
+// A default export that is not a handler. Also a script, not a server.
+export default { name: "not a handler", port: 1234 };
+console.log("no-fetch script ran");

--- a/tests/fixtures/fetch-handler/plain.mjs
+++ b/tests/fixtures/fetch-handler/plain.mjs
@@ -1,0 +1,2 @@
+// No default export at all: this file must run and exit like any other script.
+console.log("plain script ran");

--- a/tests/fixtures/fetch-handler/server.cjs
+++ b/tests/fixtures/fetch-handler/server.cjs
@@ -1,0 +1,6 @@
+// The CommonJS spelling of the same shape.
+module.exports = {
+  fetch() {
+    return new Response("hello from commonjs");
+  },
+};

--- a/tests/fixtures/fetch-handler/server.mjs
+++ b/tests/fixtures/fetch-handler/server.mjs
@@ -1,0 +1,32 @@
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+    if (url.pathname === "/echo") {
+      return new Response(request.body, {
+        status: 201,
+        headers: { "x-method": request.method, "x-seen": request.headers.get("x-send") ?? "" },
+      });
+    }
+    if (url.pathname === "/cookies") {
+      const headers = new Headers();
+      headers.append("set-cookie", "a=1; Expires=Wed, 21 Oct 2026 07:28:00 GMT");
+      headers.append("set-cookie", "b=2");
+      return new Response("cookies", { headers });
+    }
+    if (url.pathname === "/stream") {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("chunk-one\n"));
+          controller.enqueue(new TextEncoder().encode("chunk-two\n"));
+          controller.close();
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/plain" } });
+    }
+    if (url.pathname === "/empty") return new Response(null, { status: 204 });
+    if (url.pathname === "/teapot") return new Response("short and stout", { status: 418 });
+    if (url.pathname === "/throw") throw new Error("handler blew up");
+    if (url.pathname === "/not-a-response") return "just a string";
+    return new Response(`hello from ${url.pathname}?${url.searchParams.get("q") ?? ""}`);
+  },
+};

--- a/tests/fixtures/fetch-handler/server.ts
+++ b/tests/fixtures/fetch-handler/server.ts
@@ -1,0 +1,14 @@
+type Greeting = { readonly name: string };
+
+// `satisfies` and the enum are non-erasable syntax on purpose: a `.ts` entry has to
+// be transpiled before its default export can be inspected at all.
+enum Status {
+  Ok = 200,
+}
+
+export default {
+  fetch(request: Request): Response {
+    const who = { name: new URL(request.url).pathname.slice(1) || "world" } satisfies Greeting;
+    return new Response(`hello ${who.name}`, { status: Status.Ok });
+  },
+};

--- a/tests/fixtures/fetch-handler/spawns-child.mjs
+++ b/tests/fixtures/fetch-handler/spawns-child.mjs
@@ -1,0 +1,22 @@
+// The serve signal must not reach a child. This entry is itself a handler, and the
+// child it spawns is the same file — so if the signal propagated, the child would
+// bind a second port and report a second `Listening on` line.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+if (!process.env.FIXTURE_IS_CHILD) {
+  const child = spawnSync(process.execPath, [fileURLToPath(import.meta.url)], {
+    env: { ...process.env, FIXTURE_IS_CHILD: "1" },
+    encoding: "utf8",
+  });
+  process.stdout.write(`child-stdout:${child.stdout.trim()}\n`);
+  process.stdout.write(`child-stderr:${child.stderr.trim()}\n`);
+} else {
+  process.stdout.write("child ran to completion\n");
+}
+
+export default {
+  fetch() {
+    return new Response("parent handler");
+  },
+};

--- a/tests/fixtures/fetch-handler/tla.mjs
+++ b/tests/fixtures/fetch-handler/tla.mjs
@@ -1,0 +1,9 @@
+// Top-level await settles before the export is inspected, so a handler assembled
+// asynchronously is still found.
+const greeting = await Promise.resolve("ready after await");
+
+export default {
+  fetch() {
+    return new Response(greeting);
+  },
+};


### PR DESCRIPTION
An entry whose default export has a `fetch` method is served over HTTP:

```ts
export default {
  fetch(request) { return new Response("hello"); },
};
```

The shape Cloudflare Workers, Bun, Deno and Vercel accept, at their one-argument intersection. The listener binds `PORT` (default 3000) on `HOST` (default every interface), and nothing else on the export is read. A taken port is fatal.

That shape is the whole gate, so a file without it runs and exits as under `node`. Excluded: `--node`, bin launches, the `node` hijack. No child or Worker inherits a listener. A compiled artifact serves it too, measured in the single-executable and `--smol` shapes.

A new `ExportedHandler` type in `@nubjs/types` turns a misspelled `fetch` key into a compile error under `satisfies`. It is module-scoped, because a global of that name merges with Cloudflare's and, under `skipLibCheck`, silently replaces its `fetch` signature.

22 tests; stubbing the installer turns 19 red. Type fixtures pin the handler as requiring `fetch` and taking one argument, and reject a misspelled key. Verified on both preload tiers, behind a Node-based env loader, behind a foreign preload that holds the event loop, and swept against `--node` for every non-server shape. The docs page stays unpublished.


